### PR TITLE
Add scroll support for many definitions

### DIFF
--- a/data.js
+++ b/data.js
@@ -428,7 +428,6 @@ if (0) {
                     if (ok) {
                         if (count >= maxTrim) {
 							entry.more = 1;
-							//break;
 						}
 
 						have[ofs] = 1;

--- a/data.js
+++ b/data.js
@@ -428,7 +428,7 @@ if (0) {
                     if (ok) {
                         if (count >= maxTrim) {
 							entry.more = 1;
-							break;
+							//break;
 						}
 
 						have[ofs] = 1;
@@ -760,7 +760,12 @@ if (0) {
 			var pK = '';
 			var k;
 
-			for (i = 0; i < entry.data.length; ++i) {
+			if (!entry.index)
+				entry.index = 0;
+
+			if (entry.index != 0) b.push('...<br/>');
+
+			for (i = entry.index; i < Math.min((7 + entry.index), entry.data.length); ++i) {
 				e = entry.data[i][0].match(/^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//);
 				if (!e) continue;
 
@@ -803,7 +808,7 @@ if (0) {
 				}
 			}
 			b.push(t);
-			if (entry.more) b.push('...<br/>');
+			if (entry.more && (entry.index < (entry.data.length - 7))) b.push('...<br/>');
 		}
 
 		return b.join('');

--- a/options.html
+++ b/options.html
@@ -45,6 +45,8 @@
 						<tr><td>B</td><td>Previous character</td></tr>
 						<tr><td>M</td><td>Next character</td></tr>
 						<tr><td>N</td><td>Next word</td></tr>
+						<tr><td>J</td><td>Scroll back definitions</td></tr>
+						<tr><td>K</td><td>Scroll forward definitions</td></tr>
 						</table>
 							<br />
 							<input type="checkbox" id="disablekeys" name="disablekeys">

--- a/rikaichan.js
+++ b/rikaichan.js
@@ -298,6 +298,8 @@ var rcxMain = {
 		'<tr><td>B</td><td>Previous character</td></tr>' +
 		'<tr><td>M</td><td>Next character</td></tr>' +
 		'<tr><td>N</td><td>Next word</td></tr>' +
+		'<tr><td>J</td><td>Scroll back definitions</td></tr>' +
+		'<tr><td>K</td><td>Scroll forward definitions</td></tr>' +
 		'</table>',
 		
 /* 			'<tr><td>C</td><td>Copy to clipboard</td></tr>' +

--- a/rikaicontent.js
+++ b/rikaicontent.js
@@ -343,9 +343,7 @@ var rcxContent = {
 				e.index = 0;
 			if (e.index > 0) e.index -= 1;
 			else e.index = e.data.length - 7;
-			//rcxContent.lastFound = [e];
-			// console.log(e.index);
-			// console.log(e.data);
+
 			chrome.extension.sendMessage({"type":"makehtml", "entry":e}, rcxContent.processHtml);
 			this.lastFound = [e];
 			break;
@@ -359,8 +357,6 @@ var rcxContent = {
 			if (e.index >= (e.data.length - 7))
 				e.index = 0;
 			else e.index += 1;
-
-			//console.log(e.index);
 
 			chrome.extension.sendMessage({"type":"makehtml", "entry":e}, rcxContent.processHtml);
 			this.lastFound = [e];

--- a/rikaicontent.js
+++ b/rikaicontent.js
@@ -334,6 +334,37 @@ var rcxContent = {
 			//chrome.extension.sendMessage({"type":"nextDict"});
 			this.show(ev.currentTarget.rikaichan, this.nextDict);
 			break;
+		case 74:	// j
+			// reverse cycle through definitions if > max (7)
+			e = this.lastFound[0];
+			if (e.data.length < 7)
+				break;
+			if (!e.index)
+				e.index = 0;
+			if (e.index > 0) e.index -= 1;
+			else e.index = e.data.length - 7;
+			//rcxContent.lastFound = [e];
+			// console.log(e.index);
+			// console.log(e.data);
+			chrome.extension.sendMessage({"type":"makehtml", "entry":e}, rcxContent.processHtml);
+			this.lastFound = [e];
+			break;
+		case 75:	// k
+			// forward cycle through definitions if > max (7)
+			e = this.lastFound[0];
+			if (e.data.length < 7)
+				break;
+			if (!e.index)
+				e.index = 0;
+			if (e.index >= (e.data.length - 7))
+				e.index = 0;
+			else e.index += 1;
+
+			//console.log(e.index);
+
+			chrome.extension.sendMessage({"type":"makehtml", "entry":e}, rcxContent.processHtml);
+			this.lastFound = [e];
+			break;
 		case 27:	// esc
 			this.hidePopup();
 			this.clearHi();


### PR DESCRIPTION
# Scenario

A rikaikun user hovers over a japanese phrase. If a given phrase has more than 7 definitions, only the first 7 can be viewed, and all of the others are unable to be viewed.

This PR allows the definitions window to be scrollable forwards and backwards when there are too many definitions to be displayed. This allows all definitions to be viewed.

Rikaikun uses the ellipsis '...' to inform the user there are more definitions than can be displayed. When this is the case, the 'J' and 'K' keys can be used to scroll through the definitions forwards and backwards respectively (with loopback both ways).
## Technical Details
- ellipsis on head and tail of definition window helps inform the user where they are. (first, middle, last)
### Todo

When I approached this codebase, the max number of display-able definitions was hard-coded at 7. Unfortunately, I have continued this practice. I assume you understand why I'd like to remove these "floating" numbers and box them into a single variable. However, I am unsure of where to add the proper constant variable declaration. Please inform me of a suitable location and I will add the commit.

Please feel free to chime in any additional notes! Thanks!
