### PR TITLE
Fix mousedown event name

### DIFF
--- a/rikaicontent.js
+++ b/rikaicontent.js
@@ -68,7 +68,7 @@ var rcxContent = {
 			window.removeEventListener('mousemove', this.onMouseMove, false);
 			window.removeEventListener('keydown', this.onKeyDown, true);
 			window.removeEventListener('keyup', this.onKeyUp, true);
-			window.removeEventListener('mosuedown', this.onMouseDown, false);
+			window.removeEventListener('mousedown', this.onMouseDown, false);
 			window.removeEventListener('mouseup', this.onMouseUp, false);
 
 			e = document.getElementById('rikaichan-css');


### PR DESCRIPTION
https://github.com/melink14/rikaikun/issues/130

When rikaikun was disabled the `mousedown` event listener never got removed
because of a misspelled event name, therefore resulting in a following
error when clicking somewhere on a page:
```
Uncaught TypeError: Cannot set property 'oldCaret' of undefined
    at Object._onMouseDown (chrome-extension://jipdnfibhldikgcjhfnomkfpcebammhp/rikaicontent.js:405)
    at onMouseDown (chrome-extension://jipdnfibhldikgcjhfnomkfpcebammhp/rikaicontent.js:392)
```