### PR TITLE
Add GDocs support and refactor options

### DIFF
--- a/background.js
+++ b/background.js
@@ -69,6 +69,7 @@ var optionsList = [
 	"textboxhl",
 	"ttsEnabled",
 	"showOnKey",
+	"inlineDivs"
 ];
 
 /** Get option data from cloud and initialize into memory. */
@@ -118,6 +119,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
 	initConfig('showOnKey', '');
 	initConfig('textboxhl', false);
 	initConfig('ttsEnabled', false);
+	initConfig('inlineDivs', false);
 
 	/**
 	 * Set kanjiInfo option values 
@@ -145,27 +147,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
  * https://developer.chrome.com/storage
  */
 function saveOptionsToCloudStorage() {
-	chrome.storage.sync.set({
-		// Saving General options
-		"disablekeys": rcxMain.config.disablekeys,
-		"highlight": rcxMain.config.highlight,
-		"kanjicomponents": rcxMain.config.kanjicomponents,
-		"kanjiInfo": rcxMain.config.kanjiInfo,
-		"maxDictEntries": rcxMain.config.maxDictEntries,
-		"minihelp": rcxMain.config.minihelp,
-		"onlyreading": rcxMain.config.onlyreading,
-		"popupcolor": rcxMain.config.popupcolor,
-		"popupDelay": rcxMain.config.popupDelay,
-		"popupLocation": rcxMain.config.popupLocation,
-		"showOnKey": rcxMain.config.showOnKey,
-		"textboxhl": rcxMain.config.textboxhl,
-		"ttsEnabled": rcxMain.config.ttsEnabled,
-
-		// Saving Copy to Clipboard settings
-		"copySeparator": rcxMain.config.copySeparator,
-		"lineEnding": rcxMain.config.lineEnding,
-		"maxClipCopyEntries": rcxMain.config.maxClipCopyEntries
-	});
+	chrome.storage.sync.set(rcxMain.config);
 }
 
 /**

--- a/options.html
+++ b/options.html
@@ -146,6 +146,11 @@
 						<input type="checkbox" id="ttsEnabled" name="ttsEnabled">
 						Enabled 
 					</div>
+					<div id="compatibility" class="tabContent">
+					<h1>Compatibility</h1>
+						<input type="checkbox" id="inlineDivs" name="inlineDivs">
+						Treat Div Elements Like Inline (Google Docs)
+					</div>
 				</div>
 			<p><input type="submit" id="submit" value="Save" /></p>
 			</form>

--- a/options.js
+++ b/options.js
@@ -11,6 +11,7 @@ function populateFormFromCloudStorage() {
 		function (cloudStorage) {
 
 			// Simple values
+
 			document.optform.disablekeys.checked = cloudStorage.disablekeys;
 			document.optform.highlighttext.checked = cloudStorage.highlight;
 			document.optform.kanjicomponents.checked = cloudStorage.kanjicomponents;
@@ -21,6 +22,7 @@ function populateFormFromCloudStorage() {
 			document.optform.popupLocation.selectedIndex = cloudStorage.popupLocation;
 			document.optform.textboxhl.checked = cloudStorage.textboxhl;
 			document.optform.ttsEnabled.checked = cloudStorage.ttsEnabled;
+			document.optform.inlineDivs.checked = cloudStorage.inlineDivs;
 
 			// Single select option groups
 			for (var i = 0; i < document.optform.copySeparator.length; ++i) {
@@ -68,65 +70,33 @@ function populateFormFromCloudStorage() {
  * String values from form are converted to number/boolean if appropriate.
  */
 function saveOptions() {
-	var copySeparator = document.optform.copySeparator.value;
-	var disablekeys = document.optform.disablekeys.checked;
-	var highlight = document.optform.highlighttext.checked;
-	var kanjicomponents = document.optform.kanjicomponents.checked;
-	var lineEnding = document.optform.lineEnding.value;
-	var maxClipCopyEntries = parseInt(document.optform.maxClipCopyEntries.value);
-	var minihelp = document.optform.minihelp.checked;
-	var onlyreading = document.optform.onlyreading.checked;
-	var popupcolor = document.optform.popupcolor.value;
-	var popupDelay = getPopUpDelay();
-	var popupLocation = document.optform.popupLocation.value;
-	var showOnKey = document.optform.showOnKey.value;
-	var textboxhl = document.optform.textboxhl.checked;
-	var ttsEnabled = document.optform.ttsEnabled.checked;
-	
 	var kanjiInfoObject = {};
 	// Setting Kanji values
 	for (var i = 0; i < kanjiInfoLabelList.length; i +=2 ) {
 		kanjiInfoObject[kanjiInfoLabelList[i]] = document.getElementById(kanjiInfoLabelList[i]).checked;
 	}
+	var options = {
+		copySeparator : document.optform.copySeparator.value,
+		disablekeys : document.optform.disablekeys.checked,
+		highlight : document.optform.highlighttext.checked,
+		kanjicomponents : document.optform.kanjicomponents.checked,
+		lineEnding : document.optform.lineEnding.value,
+		maxClipCopyEntries : parseInt(document.optform.maxClipCopyEntries.value),
+		minihelp : document.optform.minihelp.checked,
+		onlyreading : document.optform.onlyreading.checked,
+		popupcolor : document.optform.popupcolor.value,
+		popupDelay : getPopUpDelay(),
+		popupLocation : document.optform.popupLocation.value,
+		showOnKey : document.optform.showOnKey.value,
+		textboxhl : document.optform.textboxhl.checked,
+		ttsEnabled : document.optform.ttsEnabled.checked,
+		kanjiInfo: kanjiInfoObject,
+		inlineDivs: document.optform.inlineDivs.checked
+	}
+	var backgroundPage = chrome.extension.getBackgroundPage();
 
-	chrome.storage.sync.set({
-		// Saving General options
-		"disablekeys": disablekeys,
-		"highlight": highlight,
-		"kanjicomponents": kanjicomponents,
-		"kanjiInfo": kanjiInfoObject,
-		"minihelp": minihelp,
-		"onlyreading": onlyreading,
-		"popupcolor": popupcolor,
-		"popupDelay": popupDelay,
-		"popupLocation": popupLocation,
-		"showOnKey": showOnKey,
-		"textboxhl": textboxhl,
-		"ttsEnabled": ttsEnabled,
-
-		// Saving Copy to Clipboard settings
-		"copySeparator": copySeparator,
-		"lineEnding": lineEnding,
-		"maxClipCopyEntries": maxClipCopyEntries
-	});
-
-	// TODO: Inline this above and call saveOptionsToCloudStorage.
-	chrome.extension.getBackgroundPage().rcxMain.config.copySeparator = copySeparator;
-	chrome.extension.getBackgroundPage().rcxMain.config.disablekeys = disablekeys;
-	chrome.extension.getBackgroundPage().rcxMain.config.highlight = highlight;
-	chrome.extension.getBackgroundPage().rcxMain.config.kanjicomponents = kanjicomponents;
-	chrome.extension.getBackgroundPage().rcxMain.config.kanjiInfo = kanjiInfoObject;
-	chrome.extension.getBackgroundPage().rcxMain.config.lineEnding = lineEnding;
-	chrome.extension.getBackgroundPage().rcxMain.config.maxClipCopyEntries = maxClipCopyEntries;
-	chrome.extension.getBackgroundPage().rcxMain.config.minihelp = minihelp;
-	chrome.extension.getBackgroundPage().rcxMain.config.onlyreading = onlyreading;
-	chrome.extension.getBackgroundPage().rcxMain.config.popupcolor = popupcolor;
-	chrome.extension.getBackgroundPage().rcxMain.config.popupDelay = popupDelay;
-	chrome.extension.getBackgroundPage().rcxMain.config.popupLocation = popupLocation;
-	chrome.extension.getBackgroundPage().rcxMain.config.showOnKey = showOnKey;
-	chrome.extension.getBackgroundPage().rcxMain.config.textboxhl = textboxhl;
-	chrome.extension.getBackgroundPage().rcxMain.config.ttsEnabled = ttsEnabled;
-
+	backgroundPage.rcxMain.config = options;
+	backgroundPage.saveOptionsToCloudStorage();
 }
 
 function getPopUpDelay() {

--- a/rikaicontent.js
+++ b/rikaicontent.js
@@ -538,7 +538,7 @@ var rcxContent = {
 		'RP': true
 	},	
 	isInline: function(node) {
-		return this.inlineNames.hasOwnProperty(node.nodeName) || 
+		return this.inlineNames.hasOwnProperty(node.nodeName) || (node.nodeName == 'DIV' && window.rikaichan.config.inlineDivs) || 
 		// only check styles for elements
 		// comments do not have getComputedStyle method
 		(document.nodeType == Node.ELEMENT_NODE && 


### PR DESCRIPTION
### Problem

1. Google docs groups lines in a weird way where the next line is a nextSibling of a DIV. Rikaikun does not acknowledge divs as inline elements, therefore it doesn't scan the next line for the continuation of the phrase.

2. Options code is outdated and needs refactoring. The function responsible for saving the options has a TODO.

### Solution

1. Add a `Compatibility` section to the settings page, under which we include Google Docs support, which is essentially adding `DIV` into the list of inline elements (UGLY, but `false` by default and entirely optional)

2. Refactor the code in options.js and background.js to allow for an easier way to introduce an option.

### Proof

New settings section:
![image](https://user-images.githubusercontent.com/39731307/67058142-d0d96b00-f153-11e9-949d-840f823354e8.png)

Results with the setting **OFF**. 暗くis not recognised and we're suggested a singular kanji.
![image](https://user-images.githubusercontent.com/39731307/67058178-fb2b2880-f153-11e9-8f79-1e0e2b090d8c.png)
 
Results with the setting **ON**. 暗くis recognised and we're suggested the full word.
![image](https://user-images.githubusercontent.com/39731307/67058207-185ff700-f154-11e9-929c-d09bb24b2c28.png)

