### PR TITLE
style: Add prettier plugin that formats JSDoc comments and run it.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,15 @@
   },
   "ignorePatterns": "dist",
   "rules": {
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireParamDescription": false,
+        "requireReturnDescription": false,
+        "requireReturn": false,
+        "prefer": { "return": "returns" }
+      }
+    ],
     "linebreak-style": ["error", "unix"],
     "node/no-unpublished-import": "off",
     "@typescript-eslint/no-var-requires": "off",

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,12 @@ module.exports = {
   // TODO(espeed): Consider reverting bracket spacing to gts default of none.
   bracketSpacing: true,
   arrowParens: 'always',
+  overrides: [
+    {
+      files: ['*.js', '*.ts'],
+      options: {
+        parser: 'jsdoc-parser',
+      },
+    },
+  ],
 };

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -11,7 +11,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, response) {
       const e = rcxMain.search(request.text, request.dictOption);
       response(e);
       break;
-    /**  case 'nextDict':
+    /*  case 'nextDict':
 			 console.log('nextDict');
 			 rcxMain.nextDict();
 			 break;*/
@@ -79,10 +79,11 @@ chrome.storage.sync.get(optionsList, function (items) {
 
 /**
  * Initializes config with values from one of the following sources in order:
- *    1. Cloud Storage, 2. Local Storage, and 3. Default
  *
- * @param {Object<string, boolean|number|string>} cloudStorage
- *     config values retrieved from cloud storage.
+ * 1. Cloud Storage, 2. Local Storage, and 3. Default
+ *
+ * @param {Object<string, boolean | number | string>} cloudStorage Config
+ *     values retrieved from cloud storage.
  */
 function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
   /**
@@ -90,7 +91,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
    * back to `localStorage` and finally defaulting to `defaultValue`.
    *
    * @param {string} key
-   * @param {boolean|number|string} defaultValue
+   * @param {boolean | number | string} defaultValue
    */
   function initConfig(key, defaultValue) {
     let currentValue =
@@ -119,6 +120,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
 
   /**
    * Set kanjiInfo option values
+   *
    * Check each key in case there are new types of info to be added to the
    * config. TODO: Consider a solution that doesn't require this loop.
    */
@@ -172,7 +174,7 @@ function saveOptionsToCloudStorage() {
  * returns the same value coerced to the proper type.
  *
  * @param {string} value
- * @return {boolean|number|string}
+ * @returns {boolean | number | string}
  */
 function normalizeStringValue(value) {
   const maybeNumber = parseInt(value, 10);

--- a/extension/options.ts
+++ b/extension/options.ts
@@ -5,6 +5,7 @@ const kanjiInfoLabelList = chrome.extension.getBackgroundPage().RcxDict
 /**
  * Retrieves saved options from chrome.storage.sync and populates form
  * elements.
+ *
  * TODO: Perhaps using form map data, we can set these directly.
  */
 function populateFormFromCloudStorage() {
@@ -71,9 +72,9 @@ function populateFormFromCloudStorage() {
 }
 
 /**
- * Collects all options from form fields and updates in memory
- * config object as well as saves to cloud storage.
- * String values from form are converted to number/boolean if appropriate.
+ * Collects all options from form fields and updates in memory config object as
+ * well as saves to cloud storage. String values from form are converted to
+ * number/boolean if appropriate.
  */
 function saveOptions() {
   const copySeparator = document.optform.copySeparator.value;
@@ -140,9 +141,10 @@ function saveOptions() {
   chrome.extension.getBackgroundPage().rcxMain.config.ttsEnabled = ttsEnabled;
 }
 /**
- * Returns number popup Delay from form as number.
- * If value cannot be parsed, returns default 150.
- * @return {number}
+ * Returns number popup Delay from form as number. If value cannot be parsed,
+ * returns default 150.
+ *
+ * @returns {number}
  */
 function getPopUpDelay() {
   let popupDelay;

--- a/extension/texttospeech.ts
+++ b/extension/texttospeech.ts
@@ -1,6 +1,4 @@
-/**
- * Helper class for Japanese Text To Speech.
- */
+/** Helper class for Japanese Text To Speech. */
 function TTS() {
   this.lastTime = new Date().valueOf();
   this.previousText = null;
@@ -9,6 +7,7 @@ function TTS() {
 TTS.prototype = {
   /**
    * Plays text-to-speech audio for given Japanese text.
+   *
    * @param {string} text
    */
   play(text) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,6 +1191,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+      "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3773,6 +3779,15 @@
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
+      }
+    },
+    "prettier-plugin-jsdoc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.1.0.tgz",
+      "integrity": "sha512-yUhzcZLQ/XJ8BcgkDcdJ6ltvSsUdST/Aakogy9ahcESTxDPYM2FUzxZfB8i1oVpZQQK/ce+MNDIf4NsB9dBJPA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.5"
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gts": "^2.0.2",
     "iconv-lite": "^0.6.2",
     "prettier": "^2.1.1",
+    "prettier-plugin-jsdoc": "^0.1.0",
     "ts-loader": "^8.0.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2",

--- a/utils/update-db.ts
+++ b/utils/update-db.ts
@@ -93,12 +93,11 @@ const normalizeEntry = (entry) => {
   return result;
 };
 
-/**
- * Parses word and name dictionaries.
- */
+/** Parses word and name dictionaries. */
 class DictParser extends Transform {
   /**
    * Pass options as per Transform.
+   *
    * @param {Object} options
    */
   constructor(options) {
@@ -109,10 +108,11 @@ class DictParser extends Transform {
   }
 
   /**
-   * transforms data
-   * @param {*} data
-   * @param {*} encoding
-   * @param {*} callback
+   * Transforms data
+   *
+   * @param {any} data
+   * @param {any} encoding
+   * @param {any} callback
    */
   _transform(data, encoding, callback) {
     const line = data.toString('utf8');
@@ -167,6 +167,7 @@ class DictParser extends Transform {
 
   /**
    * Prints the index for given stream.
+   *
    * @param {WriteStream} stream
    */
   printIndex(stream) {
@@ -211,12 +212,11 @@ const parseEdict = (url, dataFile, indexFile) => {
   });
 };
 
-/**
- * Handles parsing of KanjiDict format.
- */
+/** Handles parsing of KanjiDict format. */
 class KanjiDictParser extends Writable {
   /**
    * Construct as per Writable.
+   *
    * @param {Object} options
    */
   constructor(options) {
@@ -226,9 +226,10 @@ class KanjiDictParser extends Writable {
 
   /**
    * Write the data.
-   * @param {*} data
-   * @param {*} encoding
-   * @param {*} callback
+   *
+   * @param {any} data
+   * @param {any} encoding
+   * @param {any} callback
    */
   _write(data, encoding, callback) {
     const line = data.toString('utf8');
@@ -354,6 +355,7 @@ class KanjiDictParser extends Writable {
 
   /**
    * Print the dictionary files
+   *
    * @param {fs.WriteStream} stream
    */
   printDict(stream) {


### PR DESCRIPTION
Update eslint config to prefer `@returns` over `@return` to match formatter.
This required mirroring some unrelated `valid-jsdoc` config due to configs not being merged.
Use two newlines to force linebreak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/melink14/rikaikun/217)
<!-- Reviewable:end -->
