### PR TITLE
chore: Update lint check to also build

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,13 +1,9 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Lint
+name: Lint/Build
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -15,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,3 +21,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run lint
+      - run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,10 @@
 
 name: Lint/Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Since a successful build is also something that can be automatically checked, let's do it.

Also made some small changes:
1. Make action run on all branches since otherwise stacked PRs don't get checks.
2. Don't run on Node 10.x since it's not active anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/melink14/rikaikun/238)
<!-- Reviewable:end -->
