### PR TITLE
fix: Remove unneeded tabs permission from manifest.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,7 @@
   "description": "A port of rikaichan for chrome. Translate Japanese by hovering over words.",
   "icons": { "48": "images/icon48.png", "128": "images/icon128.png" },
 
-  "permissions": ["tabs", "clipboardWrite", "storage"],
+  "permissions": ["clipboardWrite", "storage"],
 
   "background": {
     "page": "background.html",


### PR DESCRIPTION
As per https://developer.chrome.com/extensions/tabs the permission
is only needed if accessing sensitive tab information like URL or title.
rikaikun only needs chrome.tabs for sending messages which works fine.

TESTED: Manually tested core behavior.
Fixes #152