### PR TITLE
fix: Falsy setting values now correctly initialize.

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -90,8 +90,12 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
    * @param {boolean | number | string} defaultValue
    */
   function initConfig(key, defaultValue) {
-    let currentValue =
-      cloudStorage[key] || normalizeStringValue(localStorage[key]);
+    const cloudValue = cloudStorage[key];
+    const localValue = normalizeStringValue(localStorage[key]);
+    let currentValue = localValue;
+    if (localValue === undefined) {
+      currentValue = cloudValue;
+    }
     if (currentValue === undefined) {
       currentValue = defaultValue;
     }
@@ -124,7 +128,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
   const kanjiInfoLabelList = RcxDict.prototype.kanjiInfoLabelList;
   for (i = 0; i < kanjiInfoLabelList.length; i += 2) {
     const kanjiInfoKey = kanjiInfoLabelList[i];
-    if (cloudStorage.kanjiInfo && cloudStorage.kanjiInfo[kanjiInfoKey]) {
+    if (cloudStorage.kanjiInfo) {
       rcxMain.config.kanjiInfo[kanjiInfoKey] =
         cloudStorage.kanjiInfo[kanjiInfoKey];
     } else if (localStorage[kanjiInfoKey]) {
@@ -137,10 +141,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
   }
 }
 
-/**
- * Saves options to Google Chrome Cloud storage
- * https://developer.chrome.com/storage
- */
+/* Saves options to Google Chrome Cloud storage https://developer.chrome.com/storage */
 function saveOptionsToCloudStorage() {
   chrome.storage.sync.set({
     // Saving General options

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -90,12 +90,8 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
    * @param {boolean | number | string} defaultValue
    */
   function initConfig(key, defaultValue) {
-    const cloudValue = cloudStorage[key];
-    const localValue = normalizeStringValue(localStorage[key]);
-    let currentValue = localValue;
-    if (localValue === undefined) {
-      currentValue = cloudValue;
-    }
+    let currentValue =
+      cloudStorage[key] ?? normalizeStringValue(localStorage[key]);
     if (currentValue === undefined) {
       currentValue = defaultValue;
     }

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -90,21 +90,12 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
    * @param {boolean | number | string} defaultValue
    */
   function initConfig(key, defaultValue) {
-<<<<<<< HEAD
     const cloudValue = cloudStorage[key];
     const localValue = normalizeStringValue(localStorage[key]);
     let currentValue = localValue;
     if (localValue === undefined) {
       currentValue = cloudValue;
     }
-=======
-    let cloudValue = cloudStorage[key];
-	  let localValue = normalizeStringValue(localStorage[key]);
-	  let currentValue = localValue;
-	  if(localValue === undefined){
-		  currentValue = cloudValue;
-	  }
->>>>>>> 76f2ca9cade0ec31152633e7bd8a085498b11431
     if (currentValue === undefined) {
       currentValue = defaultValue;
     }
@@ -150,11 +141,7 @@ function initializeConfigFromCloudOrLocalStorageOrDefaults(cloudStorage) {
   }
 }
 
-<<<<<<< HEAD
 /* Saves options to Google Chrome Cloud storage https://developer.chrome.com/storage */
-=======
-/** Saves options to Google Chrome Cloud storage https://developer.chrome.com/storage */
->>>>>>> 76f2ca9cade0ec31152633e7bd8a085498b11431
 function saveOptionsToCloudStorage() {
   chrome.storage.sync.set({
     // Saving General options


### PR DESCRIPTION
I changed the logic that checks whether or not initial options values exist and whether or not they are true, to only check for whether or not they exist already. This way, if a false value for a checkbox is not mistaken for a missing setting value.

Solves issue https://github.com/melink14/rikaikun/issues/346.

--I attempted to rebase these changes as I initially committed without running the linter and I wanted to follow the "one commit per merge req" rule, however this was not recorded by Github.