### PR TITLE
fix: Update manifest.json to allow rikaikun to work in srcdoc iframes.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,6 +26,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*", "ftp://*/*", "file:///*"],
+      "matches_about_blank": true,
       "js": ["rikaicontent.js"],
       "all_frames": true
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,7 +26,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*", "ftp://*/*", "file:///*"],
-      "matches_about_blank": true,
+      "match_about_blank": true,
       "js": ["rikaicontent.js"],
       "all_frames": true
     }


### PR DESCRIPTION
Documented here: https://developer.chrome.com/docs/extensions/mv3/content_scripts/ but that page doesn't mention srcdoc. Essentially srcdoc is a way to inject html into an iframe and as such it doesn't have a `src` attribute. In this case, chrome treats the `src` attribute as `about:blank` which means without this option these types of frames won't have rikaikun injected into them.

This stackoverflow is a great overview and also implies that the documentation used to be better:
https://stackoverflow.com/questions/41408936/can-anyone-explain-that-what-is-the-use-of-match-about-blank-in-chrome-extensi

Inspired by https://github.com/birtles/rikaichamp/commit/946b3aad9ee000103e214a2e02ad1a9a08228ba4

Fixes #410