### PR TITLE
ci: Add explicit step to report comment status to PR.

### DIFF
--- a/.github/workflows/resolve-comments.yml
+++ b/.github/workflows/resolve-comments.yml
@@ -32,3 +32,12 @@ jobs:
           jq '.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved | not)) | length' | \
           checkLength"
         name: 'Unresolved Comments Check'
+      - name: The job failed
+        if: ${{ failure() }}
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: Unresolved Comments
+          description: 'There are unresolved comments.'
+          state: 'failure'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/resolve-comments.yml
+++ b/.github/workflows/resolve-comments.yml
@@ -32,12 +32,3 @@ jobs:
           jq '.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved | not)) | length' | \
           checkLength"
         name: 'Unresolved Comments Check'
-      - name: The job failed
-        if: ${{ failure() }}
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: Unresolved Comments
-          description: 'There are unresolved comments.'
-          state: 'failure'
-          sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/update-pr-status.yml
+++ b/.github/workflows/update-pr-status.yml
@@ -9,11 +9,9 @@ jobs:
   updatePRStatus:
     runs-on: ubuntu-latest
     steps:
-      - run:
-          "echo '${{github.event.workflow_run}}'"
+      - run: "echo '${{github.event.workflow_run}}'"
         name: 'workflow_run ouput'
-      - run:
-          "echo '${{github.event.workflow}}'"
+      - run: "echo '${{github.event.workflow}}'"
         name: 'workflow object output'
 
       - name: 'Set PR Status'

--- a/.github/workflows/update-pr-status.yml
+++ b/.github/workflows/update-pr-status.yml
@@ -1,0 +1,26 @@
+name: Update PR status
+on:
+  workflow_run:
+    workflows: ['No unresolved comments']
+    types:
+      - completed
+
+jobs:
+  updatePRStatus:
+    runs-on: ubuntu-latest
+    steps:
+      - run:
+          "echo '${{github.event.workflow_run}}'"
+        name: 'workflow_run ouput'
+      - run:
+          "echo '${{github.event.workflow}}'"
+        name: 'workflow object output'
+
+      - name: 'Set PR Status'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: ${{github.event.workflow_run.name}}
+          description: 'Failed with status ${{github.event.workflow_run.conclusion}}'
+          state: ${{github.event.workflow_run.conclusion}}
+          sha: ${{github.event.workflow.pull_request.head.sha}}


### PR DESCRIPTION
Due to new security measures updating the status explicitly won't work from forks so we need to use workflow run as per: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

This can't be tested before merging so it may change later.