### PR TITLE
ci: Make codeql only run on pushes to main branch and only on relevant pull requests.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,14 @@ name: 'CodeQL'
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    paths:
+      - '**/*.ts'
+      - '**/*.js'
+      - '**/*.html'
+      - '**/*.json'
   schedule:
     - cron: '0 17 * * 2'
 


### PR DESCRIPTION
For now, restricted paths to .js, .ts, .html, and .json.

Fixes #398