### PR TITLE
ci: Remove path restritions for codeql since it is a required check

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - '**/*.ts'
-      - '**/*.js'
-      - '**/*.html'
-      - '**/*.json'
   schedule:
     - cron: '0 17 * * 2'
 


### PR DESCRIPTION
Github can't differentiate between skipped and failed.