### PR TITLE
chore(build): Remove extraneous `.` from webpack copy targets

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -52,7 +52,7 @@ const config: webpack.Configuration = {
           // All files in all directories.
           from: '**/*',
           // Keep the same relative file structure.
-          to: '[path][name].[ext]',
+          to: '[path][name][ext]',
           // Exclude typescript files which are compiled by ts-loader.
           globOptions: {
             ignore: ['**/*.ts'],


### PR DESCRIPTION
- A recent update to webpack now includes the `.` as part of the `[ext]` template making this change required to avoid background..html files in `dist/`
  See https://github.com/webpack-contrib/copy-webpack-plugin/issues/574

Fixes #453