### PR TITLE
chore(build): Encode all files consistently as UTF-8 and add linter rule to enforce it.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "sort-imports-es6-autofix/sort-imports-es6": "error",
     "node/no-unpublished-import": "off",
     "@typescript-eslint/no-var-requires": "off",
+    "unicode-bom": "error",
     // TODO(espeed): Remove these and fix errors.
     "no-undef": "off",
     "prefer-arrow-callback": "off",

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
   Rikaikun
   Copyright (C) 2010 Erek Speed

--- a/extension/rikaichan.ts
+++ b/extension/rikaichan.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
   Rikaikun
   Copyright (C) 2010 Erek Speed


### PR DESCRIPTION
BOM markers were breaking chrome unpacked extension loading because webpack never adds BOM markers by default.

Fixes #455
TESTED=Built and packaged in chrome with no problems.