### PR TITLE
fix: Reset badge text to empty on extension startup

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -47,6 +47,10 @@ chrome.runtime.onMessage.addListener(function (request, sender, response) {
   }
 });
 
+// Clear browser action badge text on first load
+// Chrome preserves last state which is usually 'On'
+chrome.browserAction.setBadgeText({ text: '' });
+
 rcxMain.config = {};
 
 const optionsList = [


### PR DESCRIPTION
For some reason, chrome restores the previous badge state on restart causing inconsistency with actual rikaikun state.

TESTED=Loaded unpacked extension and used chrome://restart to ensure badge text reset.
Fixes #82