### PR TITLE
refactor(options): Move options component into it's own directory

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,7 +16,7 @@
     "default_icon": "images/ba.png"
   },
   "options_ui": {
-    "page": "options.html",
+    "page": "options/entrypoint.html",
     "open_in_tab": false
   },
   "content_scripts": [

--- a/extension/options/component.ts
+++ b/extension/options/component.ts
@@ -1,5 +1,5 @@
 import 'lit-toast/lit-toast.js';
-import { Config, getCurrentConfiguration } from './configuration';
+import { Config, getCurrentConfiguration } from '../configuration';
 import { LitElement, TemplateResult, css, html } from 'lit';
 import { until } from 'lit/directives/until.js';
 

--- a/extension/options/entrypoint.html
+++ b/extension/options/entrypoint.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="options.js" type="module"></script>
+    <script src="component.js" type="module"></script>
   </head>
   <body>
     <options-form></options-form>

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,7 +12,7 @@ const config: webpack.Configuration = {
 
   entry: {
     // Included in options.html.
-    options: path.join(__dirname, srcDir + 'options.ts'),
+    'options/component': path.join(__dirname, srcDir + 'options/component.ts'),
     // Injected into web pages.
     rikaicontent: path.join(__dirname, srcDir + 'rikaicontent.ts'),
     // These are all loaded in the background.html.


### PR DESCRIPTION
Will allow for better ogranziation once we split css and html.

Separating the move into it's own PR to preserve history.