### PR TITLE
refactor(rikaicontent): Fix compilation errors in rikaicontent.ts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/no-var-requires": "off",
     "unicode-bom": "error",
     "promise/prefer-await-to-then": "error",
+    "@typescript-eslint/unbound-method": "error",
     // TODO(espeed): Remove these and fix errors.
     "no-undef": "off",
     "prefer-arrow-callback": "off",
@@ -38,9 +39,12 @@
   "overrides": [
     {
       // TODO(espeed): Tighten this as files get cleaned up.
-      "files": ["extension/*.ts"],
+      "files": ["**/*.ts", "**/*.js"],
       "rules": {
         "tsdoc/syntax": "off"
+      },
+      "parserOptions": {
+        "project": "./tsconfig.json"
       }
     }
   ]

--- a/extension/texttospeech.ts
+++ b/extension/texttospeech.ts
@@ -3,7 +3,7 @@ class TTS {
   private static instance: TTS;
 
   lastTime = new Date().valueOf();
-  previousText = null;
+  previousText: string | null = null;
 
   private constructor() {}
 
@@ -19,7 +19,7 @@ class TTS {
    *
    * @param {string} text
    */
-  play(text) {
+  play(text: string) {
     const now = new Date().valueOf();
     const limit = this.lastTime + 1000;
     if (text != this.previousText || now > limit) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "alwaysStrict": false,
     "noImplicitUseStrict": true
   },
-  "include": ["extension/**/*.ts", "utils/*.ts", "test/**/*.ts"]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
- Fix type issues without changing logic in rikaicontent.ts
  -  Later, need to fix loose types and linter ignores.
- Fix minor issue in texttospeech.ts since it was the only one left.
- Disable unbound-method check in options LitElement since it's not lit aware and should be generally safe.

Fixes #230