### PR TITLE
ci(coverage): Adds codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  # Ignore test directory
+  - '**/test/'
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+comment:
+  require_changes: true


### PR DESCRIPTION
- Ignore tests directory for coverage
- Require 100% diff coverage
- Don't post coverage PR comments when there's no coverage change.