### PR TITLE
fix(build): Renames `.snowpack` metapath to `snowpack`

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -25,7 +25,7 @@ const config = {
   buildOptions: {
     out: 'dist',
     // The default _snowpack breaks chrome extensions.
-    metaUrlPath: '.snowpack',
+    metaUrlPath: 'snowpack',
     clean: true,
     // The extension HTML files don't have doctype strings so this is required.
     htmlFragments: true,


### PR DESCRIPTION
Chrome web store removes all 'hidden' folders when packaging extensions which it defines as folders/file with a leading `.`.

See https://bugs.chromium.org/p/chromium/issues/detail?id=23004

Fixes #607