### PR TITLE
feat: Set `offline_enabled` to true in extension manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,6 +8,7 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
+  "offline_enabled": true,
   "permissions": ["clipboardWrite", "storage"],
   "background": {
     "page": "background.html",


### PR DESCRIPTION
This should make Chrome Web Store highlight that the extension is enabled for offline use.

Fixes #429