### PR TITLE
feat(popup): Explicilty sets rikaikun to horizontal writing mode

### DIFF
--- a/extension/css/popup.css
+++ b/extension/css/popup.css
@@ -88,6 +88,7 @@
   padding: 4px;
   position: absolute;
   top: 5px;
+  writing-mode: horizontal-tb;
   z-index: 99992;
 }
 


### PR DESCRIPTION
Avoids inheriting veritcal text styles from host page when they're overly broad.

Long term, shadow dom should help, and we should also make a popup position that works well for vertical text.

Fixes #613