### PR TITLE
ci: Create presubmit script and run during ci and pre-push

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Lint/Build/Test
+name: Presubmit
 
 on:
   pull_request:
@@ -9,8 +9,7 @@ on:
     branches: [main]
 
 jobs:
-  build_and_lint:
-    name: Build, lint and test rikaikun
+  presubmit:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +19,7 @@ jobs:
         with:
           node-version: '14'
       - run: npm ci
-      - run: npm run lint
-      - run: npm run checktypes
-      - run: npm run build
-      - run: npm test -- --coverage
+      - run: npm run presubmit:coverage
       - name: Coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run presubmit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore build output
-dist

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
+    "prepare": "husky install",
     "//": "preinstall used to upgrade snowpack's esbuild internally.",
     "preinstall": "([ \"$CI\" != true ]) && npx npm-force-resolutions && echo >> package-lock.json || exit 0",
     "checktypes": "tsc --noEmit",
@@ -16,10 +17,13 @@
     "///": "For gts fix/lint, js/ts are included by default so we add mjs as an extra.",
     "fix": "npm run prettier:format --silent && gts fix **/*.mjs && npm run stylelint:fix --silent",
     "lint": "gts check **/*.mjs && npm run prettier:check --silent && npm run stylelint:check --silent",
-    "prettier:base": "prettier --config .prettierrc.js .",
+    "presubmit:base": "npm run lint && npm run checktypes && npm run build",
+    "presubmit": "npm run presubmit:base && npm test",
+    "presubmit:coverage": "npm run presubmit:base && npm test -- --coverage",
+    "prettier:base": "prettier --config .prettierrc.js --ignore-path '.gitignore' .",
     "prettier:check": "npm run prettier:base --silent -- --check",
     "prettier:format": "npm run prettier:base --silent -- --write",
-    "stylelint:check": "stylelint '**/*.css' '**/*.ts'",
+    "stylelint:check": "stylelint '**/*.css' '**/*.ts' --ignore-path '.gitignore'",
     "stylelint:fix": "npm run stylelint:check --silent -- --fix",
     "test": "wtr \"extension/**/*test*\"",
     "test:watch": "npm run test -- --watch",


### PR DESCRIPTION
- Create a version which generates coverage data for CI and one that doesn't for pre-push hook.
- Fix husky install by adding `prepare` script
- Unify ignore files to use .gitignore after noticing failures with presubmit script
- Rename generic presubmit workflow to presubmit.