### PR TITLE
test: Ensures mocha callbacks are using non arrow functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,8 @@
     "unicode-bom": "error",
     "promise/prefer-await-to-then": "error",
     "curly": "error",
-    "mocha/no-mocha-arrows": "off"
+    "prefer-arrow-callback": "off",
+    "mocha/prefer-arrow-callback": "error"
   },
   "overrides": [
     {

--- a/extension/test/background_test.ts
+++ b/extension/test/background_test.ts
@@ -8,23 +8,23 @@ use(sinonChai);
 
 let rcxMain: RcxMain;
 
-describe('background.ts', () => {
-  before(async () => {
+describe('background.ts', function () {
+  before(async function () {
     // Resolve config fetch with minimal config object.
     chrome.storage.sync.get.yields({ kanjiInfo: [] });
     // Imports only run once so run in `before` to make it deterministic.
     rcxMain = await (await import('../background')).TestOnlyRxcMainPromise;
   });
 
-  beforeEach(() => {
+  beforeEach(function () {
     // Only reset the spies we're using since we need to preserve
     // the state of `chrome.runtime.onMessage.addListener` for invoking
     // the core functionality of background.ts.
     chrome.tabs.sendMessage.reset();
   });
 
-  describe('when sent "forceDocsHtml?" message', () => {
-    it('should not call response callback when rikaikun disabled', async () => {
+  describe('when sent "forceDocsHtml?" message', function () {
+    it('should not call response callback when rikaikun disabled', async function () {
       rcxMain.enabled = 0;
       const responseCallback = sinon.spy();
 
@@ -36,7 +36,7 @@ describe('background.ts', () => {
       expect(responseCallback).to.have.not.been.called;
     });
 
-    it('should not send "showPopup" message when rikaikun disabled', async () => {
+    it('should not send "showPopup" message when rikaikun disabled', async function () {
       rcxMain.enabled = 0;
 
       await sendMessageToBackground({
@@ -46,7 +46,7 @@ describe('background.ts', () => {
       expect(chrome.tabs.sendMessage).to.have.not.been.called;
     });
 
-    it('should pass true to response callback when rikaikun enabled', async () => {
+    it('should pass true to response callback when rikaikun enabled', async function () {
       rcxMain.enabled = 1;
       const responseCallback = sinon.spy();
 
@@ -58,7 +58,7 @@ describe('background.ts', () => {
       expect(responseCallback).to.have.been.calledOnceWith(true);
     });
 
-    it('should send "showPopup" message when rikaikun enabled', async () => {
+    it('should send "showPopup" message when rikaikun enabled', async function () {
       rcxMain.enabled = 1;
 
       await sendMessageToBackground({

--- a/extension/test/docs-html-fallback_test.ts
+++ b/extension/test/docs-html-fallback_test.ts
@@ -9,27 +9,27 @@ declare global {
 
 let forceHtmlCallback: (force: boolean) => void;
 
-describe('docs-html-fallback.ts after sending `forceDocsHtml?` message', () => {
-  before(async () => {
+describe('docs-html-fallback.ts after sending `forceDocsHtml?` message', function () {
+  before(async function () {
     await import('../docs-html-fallback');
     forceHtmlCallback = chrome.runtime.sendMessage.args[0][1];
   });
 
-  beforeEach(() => {
+  beforeEach(function () {
     chrome.reset();
     window._docs_force_html_by_ext = undefined;
   });
 
-  describe('when `forceHtml` callback is called with `false`', () => {
-    it('should not add special property to window object', async () => {
+  describe('when `forceHtml` callback is called with `false`', function () {
+    it('should not add special property to window object', async function () {
       forceHtmlCallback(false);
 
       expect(window._docs_force_html_by_ext).to.be.undefined;
     });
   });
 
-  describe('when `forceHtml` callback is called with `true`', () => {
-    it('should set special property to rikaikun extension ID', async () => {
+  describe('when `forceHtml` callback is called with `true`', function () {
+    it('should set special property to rikaikun extension ID', async function () {
       chrome.runtime.id = 'test_special_id';
 
       forceHtmlCallback(true);

--- a/extension/test/rikaicontent_test.ts
+++ b/extension/test/rikaicontent_test.ts
@@ -10,16 +10,16 @@ use(sinonChai);
 
 let rcxContent = new TestOnlyRcxContent();
 
-describe('RcxContent', () => {
-  beforeEach(() => {
+describe('RcxContent', function () {
+  beforeEach(function () {
     chrome.reset();
     rcxContent = new TestOnlyRcxContent();
     // Default enable rcxContent since no tests care about that now.
     rcxContent.enableTab({ showOnKey: '' } as Config);
   });
-  describe('.show', () => {
-    describe('when given Japanese word interrupted with text wrapped by `display: none`', () => {
-      it('sends "xsearch" message with invisible text omitted', () => {
+  describe('.show', function () {
+    describe('when given Japanese word interrupted with text wrapped by `display: none`', function () {
+      it('sends "xsearch" message with invisible text omitted', function () {
         const span = insertHtmlIntoDomAndReturnFirstTextNode(
           '<span>試<span style="display:none">test</span>す</span>'
         );
@@ -33,8 +33,8 @@ describe('RcxContent', () => {
       });
     });
 
-    describe('when given Japanese word interrupted with text wrapped by `visibility: hidden`', () => {
-      it('sends "xsearch" message with invisible text omitted', () => {
+    describe('when given Japanese word interrupted with text wrapped by `visibility: hidden`', function () {
+      it('sends "xsearch" message with invisible text omitted', function () {
         const span = insertHtmlIntoDomAndReturnFirstTextNode(
           '<span>試<span style="visibility: hidden">test</span>す</span>'
         );
@@ -48,8 +48,8 @@ describe('RcxContent', () => {
       });
     });
 
-    describe('when given Japanese word is interrupted with text wrapped by visible span', () => {
-      it('sends "xsearch" message with all text included', () => {
+    describe('when given Japanese word is interrupted with text wrapped by visible span', function () {
+      it('sends "xsearch" message with all text included', function () {
         const rcxContent = new TestOnlyRcxContent();
         const span = insertHtmlIntoDomAndReturnFirstTextNode(
           '<span>試<span>test</span>す</span>'
@@ -65,12 +65,12 @@ describe('RcxContent', () => {
     });
   });
 
-  describe('mousemove', () => {
-    afterEach(() => {
+  describe('mousemove', function () {
+    afterEach(function () {
       sinon.restore();
     });
 
-    it('handled without logging errors if `caretRangeFromPoint` returns null', () => {
+    it('handled without logging errors if `caretRangeFromPoint` returns null', function () {
       sinon
         .stub(document, 'caretRangeFromPoint')
         .returns(null as unknown as Range);
@@ -81,7 +81,7 @@ describe('RcxContent', () => {
       expect(console.log).to.not.have.been.called;
     });
 
-    it('triggers xsearch message when above Japanese text', async () => {
+    it('triggers xsearch message when above Japanese text', async function () {
       const clock = sinon.useFakeTimers();
       const span = insertHtmlIntoDomAndReturnFirstTextNode(
         '<span>先生test</span>'
@@ -101,12 +101,12 @@ describe('RcxContent', () => {
     });
   });
 
-  describe('showPopup', () => {
-    afterEach(() => {
+  describe('showPopup', function () {
+    afterEach(function () {
       rcxContent.disableTab();
     });
 
-    it('sets data-theme attribute of rikaikun window to config popupcolor value', () => {
+    it('sets data-theme attribute of rikaikun window to config popupcolor value', function () {
       rcxContent.enableTab({ popupcolor: 'redtest' } as Config);
 
       rcxContent.showPopup('<span></span>');
@@ -118,7 +118,7 @@ describe('RcxContent', () => {
       ).to.equal('redtest');
     });
 
-    it('adds link tag pointing to "css/popup.css" to <head>', () => {
+    it('adds link tag pointing to "css/popup.css" to <head>', function () {
       chrome.extension.getURL.callsFake((path: string) => {
         return `http://fakebaseurl/${path}`;
       });


### PR DESCRIPTION
Arrow functions always bind `this`, but mocha exposes testing data on a custom `this`. The mocha spefic lint rule ensures that arrow functions are used everywhere else except mocha tests.

See https://mochajs.org/#arrow-functions