### PR TITLE
test: Fixes coverage logspam and SpecReporter undef errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:format": "npm run prettier:base --silent -- --write",
     "stylelint:check": "stylelint '**/*.css' '**/*.ts' --ignore-path '.gitignore'",
     "stylelint:fix": "npm run stylelint:check --silent -- --fix",
-    "test": "wtr \"extension/**/*test*\"",
+    "test": "wtr \"extension/test/*test*\"",
     "test:watch": "npm run test -- --watch",
     "update-db": "ts-node --project tsconfig_node.json utils/update-db"
   },

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -45,7 +45,7 @@ const config = {
 
 if (process.env.NODE_ENV === 'test') {
   // Add sourcemaps for easy debugging.
-  config.buildOptions.sourcemap = true;
+  config.buildOptions.sourcemap = 'inline';
   // Remove plugin which replaces test only exports.
   config.plugins = [];
 }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -29,6 +29,9 @@ class SpecReporter {
    * @returns
    */
   outputSuite(suite, indent = '') {
+    if (suite === undefined) {
+      return 'Suite is undefined; top level error';
+    }
     let results = `${indent}${suite.name}\n`;
     results +=
       suite.tests
@@ -39,6 +42,11 @@ class SpecReporter {
           } else if (test.passed) {
             result += `${this.color.green} ✓ ${this.color.reset}${this.color.dim}${test.name}`;
           } else {
+            if (test.error === undefined) {
+              test.error = {};
+              test.error.message = 'Test failed with no error message';
+              test.error.stack = '<no stack trace>';
+            }
             result += `${this.color.red} ${test.name}\n\n${test.error.message}\n${test.error.stack}`;
           }
           result +=
@@ -68,6 +76,9 @@ class SpecReporter {
   async generateTestReport(testFile, sessionsForTestFile) {
     let results = '';
     sessionsForTestFile.forEach((session) => {
+      if (session.testResults === undefined) {
+        return session.status + '\n\n';
+      }
       results += session.testResults.suites
         .map((suite) => this.outputSuite(suite, ''))
         .join('\n\n');
@@ -101,7 +112,7 @@ class SpecReporter {
 /** @type {import('@web/test-runner').TestRunnerConfig} */
 export default {
   coverageConfig: {
-    exclude: ['**/.snowpack/**/*', '**/*.test.ts*'],
+    exclude: ['**/snowpack/**/*', '**/*.test.ts*'],
   },
   browsers: [
     puppeteerLauncher({
@@ -125,7 +136,7 @@ export default {
     </html>`,
   reporters: [
     // Gives overall test progress across all tests.
-    defaultReporter({ reportTestResults: false, reportTestProgress: true }),
+    defaultReporter({ reportTestResults: true, reportTestProgress: true }),
     // Gives detailed description of chai test spec results.
     new SpecReporter().specReporter(),
   ],


### PR DESCRIPTION
- Coverage log spam errors are fixed by explicitly setting sourcemaps to be inline.
- Inline source maps appears to increase latency so increase default timeout to 5s.
- Sometimes SpecReporter is given test results that are incomplete so guards are added to make sure it doesn't throw errors.
  - Later, we should incorporate DefaultReporter's top level error reporting. Until then,I've enabled both reporters to make sure we get all the test results.
- The `snowpack` meta directory is now properly excluded from the coverage report.
- Fixes the `npm test` script to be only include the `test` directory.