### PR TITLE
ci(mergify): Migrate from strict merge to mergify queue action and from `commit_message` to `commit_message_template`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Github branch protections is enough but mergify doesn't work with no conditions
+      - label!=work-in-progress
+
 pull_request_rules:
   - name: Automatic merge when Github conditions pass
     conditions:
@@ -12,10 +18,12 @@ pull_request_rules:
       # Don't run on PRs by dependabot (or users with dependabot in their name)
       - author~=^(?:(?!dependabot).)*$
     actions:
-      merge:
+      queue:
+        name: default
         # Each PR is one commit, but may have extras added during review so squash.
         method: squash
-        # Will update PRs before merging but will start with PRs that don't need updating.
-        strict: smart+fasttrack
         # Uses original PR title and body for squashed commit message.
-        commit_message: title+body
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+          
+          {{ body }}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,5 +25,5 @@ pull_request_rules:
         # Uses original PR title and body for squashed commit message.
         commit_message_template: |
           {{ title }} (#{{ number }})
-          
+
           {{ body }}


### PR DESCRIPTION
This change has been made by @melink14 from https://mergify.com config editor.