### PR TITLE
chore(release): Add package-lock.json as an asset to commit during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
           "assets": [
             "CHANGELOG.md",
             "extension/manifest.json",
-            "package.json"
+            "package.json",
+            "package-lock.json"
           ],
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
         }


### PR DESCRIPTION
The version field is updated in package-lock.json as well and until now it's only been updated in the next commit as an unrelated change.