### PR TITLE
feat: Enables Google docs annotate canvas in manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "matches": ["https://docs.google.com/*"],
-      "js": ["docs-html-fallback.js"],
+      "js": ["docs-annotate-canvas.js"],
       "run_at": "document_start",
       "all_frames": true
     }


### PR DESCRIPTION
Previous implementation (bb9b254) of this functionality breaks due to no manifest change.

This one is marked feat since the previous attempt was marked 'fix' accidentally.

Fixes #865