### PR TITLE
chore(commitlint): Remove max line length for footer

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     // Max line lengths is an antipattern.
     'body-max-line-length': [0],
     'header-max-length': [0],
+    'footer-max-line-length': [0],
     // Consistently require no period at the end of summary.
     'header-full-stop': [2, 'never', '.'],
   },


### PR DESCRIPTION
Since commitlint doesn't properly detect footers and max line lengths are an antipattern, this change will reduce false positive noise for no cost.