### PR TITLE
ci(dependabot): Update dependabot to use build and ci type instead of chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,13 @@ updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     commit-message:
-      prefix: 'chore(deps)'
+      prefix: 'build(deps)'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: 'daily'
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'
     commit-message:
-      prefix: 'chore(actions)'
+      prefix: 'ci(deps)'


### PR DESCRIPTION
chore is too generic and ecosystem is moving to more specific types.