### PR TITLE
ci(update-dicts): Don't install git hooks when updating dictionaries

### DIFF
--- a/.github/workflows/update-dicts.yml
+++ b/.github/workflows/update-dicts.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: '16'
       - name: Update dictionaries
         run: |
-          npm ci
+          npm ci --ignore-scripts
           echo 'update_output<<EOF' >> $GITHUB_ENV
           npm run update-db >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV


### PR DESCRIPTION
Saves time and prevents flaky environment from preventing dictionary update PR.