### PR TITLE
ci(release): Install Japanese fonts before running release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/setup-node@v3.1.0
         with:
           node-version: 16
+      - name: Install Japanese Fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install fonts-noto-cjk
       - name: Install dependencies and build
         run: npm ci
       - name: Release


### PR DESCRIPTION
Some presubmit tests fail in the absence of Japanese fonts and I'd prefer the tests still run since the release script pushes directly to the repo.