### PR TITLE
ci(deps): Auto approve and merge Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,19 @@ version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
+    rebase-strategy: disabled
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+      time: '05:00'
+      timzezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'build(deps)'
   - package-ecosystem: 'github-actions'
     directory: '/'
+    rebase-strategy: disabled
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: 'weekly'
+      interval: 'daily'
+      time: '05:00'
+      timzezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'ci(deps)'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     schedule:
       interval: 'daily'
       time: '03:00'
-      timzezone: 'Asia/Tokyo'
+      timezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'build(deps)'
   - package-ecosystem: 'github-actions'
@@ -20,6 +20,6 @@ updates:
     schedule:
       interval: 'daily'
       time: '03:00'
-      timzezone: 'Asia/Tokyo'
+      timezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'ci(deps)'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,19 +7,19 @@ version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
-    rebase-strategy: disabled
+    open-pull-requests-limit: 1
     schedule:
       interval: 'daily'
-      time: '05:00'
+      time: '03:00'
       timzezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'build(deps)'
   - package-ecosystem: 'github-actions'
     directory: '/'
-    rebase-strategy: disabled
+    open-pull-requests-limit: 1
     schedule:
       interval: 'daily'
-      time: '05:00'
+      time: '03:00'
       timzezone: 'Asia/Tokyo'
     commit-message:
       prefix: 'ci(deps)'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,8 +12,8 @@ pull_request_rules:
       # Don't auto-merge PRs where non dep change had to be committed as well
       - '#commits=1'
     actions:
-      squash:
-      commit_message: first-commit
+      merge:
+        method: squash
 
   - name: Automatic merge when Github conditions pass
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,23 +8,12 @@ pull_request_rules:
       # Also covered by Github protections but this reduces noise from mergify.
       - '#approved-reviews-by>=1'
       - author=dependabot[bot]
+      - '#commits-behind=0'
+      # Don't auto-merge PRs where non dep change had to be committed as well
+      - '#commits=1'
     actions:
-      queue:
-        name: default
-        # Each PR is one commit, but may have extras added during review so squash.
-        method: squash
-        commit_message_template: |
-          {{ commits[0].message }}
-
-  - name: Recreate dependabot PR on conflict
-    conditions:
-      # Also covered by Github protections but this reduces noise from mergify.
-      - '#approved-reviews-by>=1'
-      - author=dependabot[bot]
-      - conflict
-    actions:
-      comment:
-        message: '@dependabot recreate'
+      squash:
+      commit_message: first-commit
 
   - name: Automatic merge when Github conditions pass
     conditions:
@@ -48,16 +37,3 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
-
-  - name: Notify author on queue failure
-    conditions:
-      - 'check-failure=Queue: Embarked in merge train'
-    actions:
-      comment:
-        message: >
-          Hey @{{ author }}, this pull request failed to merge and has been
-          dequeued from the merge train.  If you believe your PR failed in
-          the merge train because of a flaky test, requeue it by commenting
-          with `@mergifyio requeue`.
-          More details can be found on the `Queue: Embarked in merge train`
-          check-run.

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,10 +1,31 @@
 queue_rules:
   - name: default
-    conditions:
-      # Github branch protections is enough but mergify doesn't work with no conditions
-      - label!=work-in-progress
+    conditions: [] # no extra conditions needed to get merged
 
 pull_request_rules:
+  - name: Auto-merge dependabot
+    conditions:
+      # Also covered by Github protections but this reduces noise from mergify.
+      - '#approved-reviews-by>=1'
+      - author=dependabot[bot]
+    actions:
+      queue:
+        name: default
+        # Each PR is one commit, but may have extras added during review so squash.
+        method: squash
+        commit_message_template: |
+          {{ commits[0].message }}
+
+  - name: Recreate dependabot PR on conflict
+    conditions:
+      # Also covered by Github protections but this reduces noise from mergify.
+      - '#approved-reviews-by>=1'
+      - author=dependabot[bot]
+      - conflict
+    actions:
+      comment:
+        message: '@dependabot recreate'
+
   - name: Automatic merge when Github conditions pass
     conditions:
       # Also covered by Github protections but this reduces noise from mergify.
@@ -27,3 +48,16 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
+
+  - name: Notify author on queue failure
+    conditions:
+      - 'check-failure=Queue: Embarked in merge train'
+    actions:
+      comment:
+        message: >
+          Hey @{{ author }}, this pull request failed to merge and has been
+          dequeued from the merge train.  If you believe your PR failed in
+          the merge train because of a flaky test, requeue it by commenting
+          with `@mergifyio requeue`.
+          More details can be found on the `Queue: Embarked in merge train`
+          check-run.

--- a/.github/workflows/auto-approve-deps.yml
+++ b/.github/workflows/auto-approve-deps.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-approve
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Checking the author will prevent your Action run failing on non-Dependabot PRs
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch and confirm dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.0
+      - uses: actions/checkout@v3.0.1
+      - name: Approve a PR if not already approved
+        run: |
+          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL"
+          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Uses dependabot/fetch-metadata to validate and approve PR and mergify to do final merge. Mergify doesn't support `first-commit` for queues which may be required due to merge commits. Instead, limit Dependabot to 1 open PR at a time and have Mergify merge them when ready. This avoids extra rebasing that happens when PRs are submitted one by one. Mergify will only attempt to merge when PRs are approved, have a single commit, and are caught up with main.