### PR TITLE
docs(readme): Update and fix badges plus re-generate table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,15 @@
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/jipdnfibhldikgcjhfnomkfpcebammhp?style=flat)](https://chrome.google.com/webstore/detail/rikaikun/jipdnfibhldikgcjhfnomkfpcebammhp)
 [![Chrome Web Store Users](https://img.shields.io/chrome-web-store/users/jipdnfibhldikgcjhfnomkfpcebammhp?style=flat)](https://chrome.google.com/webstore/detail/rikaikun/jipdnfibhldikgcjhfnomkfpcebammhp)
-[![Mergify Status](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/melink14/rikaikun&style=flat)](https://mergify.io)
+[![Mergify Status](https://img.shields.io/endpoint.svg?url=https://api.mergify.com/v1/badges/melink14/rikaikun&style=flat)](https://mergify.com)
 [![codecov](https://codecov.io/gh/melink14/rikaikun/branch/main/graph/badge.svg?token=4nZ7madoqJ)](https://codecov.io/gh/melink14/rikaikun)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/e342d582357449f38d9255c247e37159)](https://www.codacy.com/gh/melink14/rikaikun/dashboard?utm_source=github.com&utm_medium=referral&utm_content=melink14/rikaikun&utm_campaign=Badge_Grade)
+[![semantic-release: conventional](https://img.shields.io/badge/semantic--release-conventional-commits?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 [![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 [![License GPL-3.0](https://img.shields.io/github/license/melink14/rikaikun?style=flat)](https://github.com/melink14/rikaikun/blob/main/LICENSE)
 [![Standard Readme Compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat)](https://github.com/RichardLitt/standard-readme)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat)](https://conventionalcommits.org)
-
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-25-orange.svg?style=flat)](#contributors)
-
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
+[![All Contributors](https://img.shields.io/github/all-contributors/melink14/rikaikun?color=orange)](#contributors)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md)
 
 rikaikun is a Chrome extension that helps you to read Japanese web pages by showing the reading and English definition of Japanese words when you hover over them.
@@ -26,6 +21,7 @@ rikaikun is a Chrome extension that helps you to read Japanese web pages by show
   - [Current Goals](#current-goals)
 - [Install](#install)
   - [Via the Chrome Web Store](#via-the-chrome-web-store)
+  - [Via Microsoft Edge Add-ons](#via-microsoft-edge-add-ons)
   - [As an Unpacked Extension](#as-an-unpacked-extension)
 - [Usage](#usage)
   - [Features](#features)


### PR DESCRIPTION
- Updates mergify to a working badge endpoint
- Switches to dynamic all contributors badge and removes comments which broke formatting
- Adds new semantic release badge.
- Table of contents was re-generated with link to installing on Edge. (Was missed in previous updates)