### PR TITLE
ci(mergify): Tell Dependabot to recreate PRs when there's a conflict

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,7 +25,7 @@ pull_request_rules:
       - conflict
     actions:
       comment:
-        message: '@dependabot rebase'
+        message: '@dependabot recreate'
 
   - name: Approve PRs by melink14 after they are marked ready
     conditions:


### PR DESCRIPTION
Dependabot can't rebase PRs that have been edited and conflicts only occur when Mergify done it's own update.