### PR TITLE
fix(rikaicontent): Properly check for text areas and input elements when deciding to save cursor information on mousedown

### DIFF
--- a/extension/rikaicontent.ts
+++ b/extension/rikaicontent.ts
@@ -511,10 +511,13 @@ class RcxContent {
     // oldCaret to -1 as an indicator not to restore position
     // Otherwise, we switch our saved textarea to whereever
     // we just clicked
-    if (!('form' in ev.target!)) {
-      window.rikaichan!.oldCaret = -1;
-    } else {
+    if (
+      ev.target instanceof HTMLTextAreaElement ||
+      ev.target instanceof HTMLInputElement
+    ) {
       window.rikaichan!.oldTA = ev.target;
+    } else {
+      window.rikaichan!.oldCaret = -1;
     }
   }
 

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -25,7 +25,7 @@ describe('data.ts', function () {
   // Increase timeout from 2000ms since data tests can take longer.
   // Make it relative to current timeout so config level changes are taken
   // into account. (ie browserstack)
-  this.timeout(this.timeout() * 2);
+  this.timeout(this.timeout() * 3);
   before(async function () {
     // stub sinon chrome getURL method to return the path it's given
     // Required to load dictionary files.

--- a/extension/test/rikaicontent_test.ts
+++ b/extension/test/rikaicontent_test.ts
@@ -924,6 +924,7 @@ describe('RcxContent', function () {
 
       expect(window.rikaichan?.oldCaret).to.equal(-1);
     });
+
     it('saves text box element in `oldTA` when clicking inside a text area', function () {
       const textarea = insertHtmlIntoDomAndReturnFirstTextNode(
         '<textarea>testtest</textarea>'
@@ -933,6 +934,7 @@ describe('RcxContent', function () {
 
       expect(window.rikaichan?.oldTA).to.equal(textarea);
     });
+
     it('saves text box element in `oldTA` when clicking inside an input box', function () {
       const input = insertHtmlIntoDomAndReturnFirstTextNode(
         '<input>testtest</input>'

--- a/extension/test/rikaicontent_test.ts
+++ b/extension/test/rikaicontent_test.ts
@@ -914,6 +914,36 @@ describe('RcxContent', function () {
     });
   });
 
+  describe('mouseDown', function () {
+    it('clears oldCaret value when clicking outside text box', function () {
+      const span = insertHtmlIntoDomAndReturnFirstTextNode(
+        '<span>testtest</span>'
+      ) as HTMLSpanElement;
+
+      triggerLeftMouseDownAtElementStart(span);
+
+      expect(window.rikaichan?.oldCaret).to.equal(-1);
+    });
+    it('saves text box element in `oldTA` when clicking inside a text area', function () {
+      const textarea = insertHtmlIntoDomAndReturnFirstTextNode(
+        '<textarea>testtest</textarea>'
+      ) as HTMLTextAreaElement;
+
+      triggerLeftMouseDownAtElementStart(textarea);
+
+      expect(window.rikaichan?.oldTA).to.equal(textarea);
+    });
+    it('saves text box element in `oldTA` when clicking inside an input box', function () {
+      const input = insertHtmlIntoDomAndReturnFirstTextNode(
+        '<input>testtest</input>'
+      ) as HTMLInputElement;
+
+      triggerLeftMouseDownAtElementStart(input);
+
+      expect(window.rikaichan?.oldTA).to.equal(input);
+    });
+  });
+
   describe('processEntry', function () {
     describe('when highlight config option enabled', function () {
       it('does not try to highlight text in Google Docs', function () {
@@ -1022,6 +1052,14 @@ function triggerMousemoveAtElementStartWithOffset(
   simulant.fire(element, 'mousemove', {
     clientX: Math.ceil(element.getBoundingClientRect().left + offset.x),
     clientY: Math.ceil(element.getBoundingClientRect().top + offset.y),
+  });
+}
+
+function triggerLeftMouseDownAtElementStart(element: Element) {
+  simulant.fire(element, 'mousedown', {
+    button: 0,
+    clientX: Math.ceil(element.getBoundingClientRect().left),
+    clientY: Math.ceil(element.getBoundingClientRect().top),
   });
 }
 


### PR DESCRIPTION
The previous logic required the text box to be in a `<form>` element which is not often true.

A follow up to this should be to also handle other cases like `content: editable`. I'm not sure how that works now though so maybe it's fine.

Also, update the timeout for data_test.ts since it wasn't long enough to complete on the normal Github Codespace.