### PR TITLE
ci(mergify): When there is a conflict, have dependabot rebase instead of recreate

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,7 +25,7 @@ pull_request_rules:
       - conflict
     actions:
       comment:
-        message: '@dependabot recreate'
+        message: '@dependabot rebase'
 
   - name: Approve PRs by melink14 after they are marked ready
     conditions:


### PR DESCRIPTION
Originally, `recreate` was used in case the Dependabot PR had already had a merge commit pushed to it since `rebase` doesn't work on modified PRs. I had assumed that all conflicts would have at least 1 commit but it seems like conflict state happens before a commit is made (I guess a commit can't be finalized if there's a conflict)

In this case, rebase should work in almost all cases since each PR should get at most one merge commit when it's at the head of the queue. In special cases, where humans interrupt the queue there could be a problem but that is probably enough of an edge case to ignore.