### PR TITLE
ci: Update release workflow to use latest lts node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: 16
+          node-version: lts/*
       - name: Install Japanese Fonts
         run: |
           sudo apt-get update


### PR DESCRIPTION
semantic-release no longer supports < node 18 but given their aggressive node policy it's less work to just always use latest lts node version which is guranteed to work.