### PR TITLE
build(deps): Unbump stylelint-config-prettier to 9.04

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snowpack": "^3.8.8",
         "snowpack-plugin-replace": "^1.0.4",
         "stylelint": "^14.16.1",
-        "stylelint-config-prettier": "^9.0.5",
+        "stylelint-config-prettier": "^9.0.4",
         "stylelint-config-standard": "^29.0.0",
         "stylelint-order": "^6.0.2",
         "ts-lit-plugin": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "snowpack": "^3.8.8",
     "snowpack-plugin-replace": "^1.0.4",
     "stylelint": "^14.16.1",
-    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-standard": "^29.0.0",
     "stylelint-order": "^6.0.2",
     "ts-lit-plugin": "^1.2.1",


### PR DESCRIPTION
Installing the latest version makes updating stylelint impossible due to new peer dependency.

Later, we'll remove this package once stylelint is updated.