### PR TITLE
ci: Make presubmit workflow use pull_request_target

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -4,7 +4,7 @@
 name: Presubmit
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
This might not be secure but should confirm if this allows commiting to PRs from forks.