### PR TITLE
build(test-runner): Allow setting `executablePath` via an environment variable

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -129,7 +129,9 @@ const defaultConfig = {
   browsers: [
     puppeteerLauncher({
       launchOptions: {
-        executablePath: '/usr/bin/google-chrome',
+        executablePath: process.env.RIKAIKUN_PUPPETEER_EXEC_PATH
+          ? process.env.RIKAIKUN_PUPPETEER_EXEC_PATH
+          : '/usr/bin/google-chrome',
         headless: true,
         args: chromeArgs,
       },


### PR DESCRIPTION
The current hardcoded path `/usr/bin/google-chrome` doesn't exist in dev environments like Mac OS making it hard to run tests locally. This change keeps the default but allows developers to override that with the path of their choosing.