### PR TITLE
fix: Return early if search string is empty

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -40,6 +40,10 @@ chrome.runtime.onMessage.addListener(async (request, sender, response) => {
       rcxMain.onTabSelect(sender.tab.id);
       break;
     case 'xsearch':
+      if (request.text === '') {
+        console.log('returning early due to empty string search');
+        break;
+      }
       console.log('xsearch');
       response(rcxMain.search(request.text, request.dictOption));
       break;

--- a/extension/test/background_test.ts
+++ b/extension/test/background_test.ts
@@ -67,10 +67,10 @@ describe('background.ts', function () {
     });
   });
   describe('xsearch', function () {
-    it('should call response callback with search results', async function () {
+    it('should call response callback with search string and dictOptions value', async function () {
       rcxMain.search = sinon
         .stub()
-        .returns({ type: 'theType', text: 'theText' });
+        .returns({ text: 'theText', dictOptions: '0' });
       const response = sinon.spy();
 
       await sendMessageToBackground({
@@ -81,13 +81,13 @@ describe('background.ts', function () {
       });
 
       expect(response).to.have.been.calledWithMatch({
-        type: 'theType',
         text: 'theText',
+        dictOptions: sinon.match.any,
       });
       expect(response).to.have.been.calledOnce;
     });
 
-    it('should not search if text is empty', async function () {
+    it('should not search if request.text is an empty string', async function () {
       const response = sinon.spy();
 
       await sendMessageToBackground({


### PR DESCRIPTION
Added catch for empty strings being passed in to return early.

Updated `background.test.ts` helper function `sendMessageToBackground` to take in optional `text` argument.

Fixes: #1417 