### PR TITLE
refactor(makeText): Rename variables, move variables to local scope

### DIFF
--- a/extension/data.ts
+++ b/extension/data.ts
@@ -940,7 +940,6 @@ class RcxDict {
   }
 
   makeText(entry: DictEntryData | null, max: number): string {
-    let i;
     let j;
     let t;
 
@@ -962,7 +961,7 @@ class RcxDict {
         b.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
+      for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const e = this.kanjiInfoLabelList[i];
         j = entry.misc[e];
         b.push(
@@ -976,7 +975,7 @@ class RcxDict {
       if (max > entry.data.length) {
         max = entry.data.length;
       }
-      for (i = 0; i < max; ++i) {
+      for (let i = 0; i < max; ++i) {
         const e = entry.data[i].entry.match(
           /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//
         );

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -961,8 +961,8 @@ class RcxDict {
       }
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
-        const e = this.kanjiInfoLabelList[i];
-        const j = entry.misc[e];
+        const kanjiInfoCode = this.kanjiInfoLabelList[i];
+        const j = entry.misc[kanjiInfoCode];
         result.push(
           this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
             '\t' +

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -979,14 +979,15 @@ class RcxDict {
         if (!entryMatch) {
           continue;
         }
+        const [_, word, pronunciation, definitions] = entryMatch;
 
-        if (entryMatch[2]) {
-          result.push(entryMatch[1] + '\t' + entryMatch[2]);
+        if (pronunciation) {
+          result.push(word + '\t' + pronunciation);
         } else {
-          result.push(entryMatch[1]);
+          result.push(word);
         }
 
-        const t = entryMatch[3].replace(/\//g, '; ');
+        const t = definitions.replace(/\//g, '; ');
         result.push('\t' + t + '\n');
       }
     }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -940,7 +940,6 @@ class RcxDict {
   }
 
   makeText(entry: DictEntryData | null, max: number): string {
-    let j;
     let t;
 
     if (entry === null) {
@@ -963,7 +962,7 @@ class RcxDict {
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const e = this.kanjiInfoLabelList[i];
-        j = entry.misc[e];
+        const j = entry.misc[e];
         b.push(
           this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
             '\t' +

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -962,11 +962,12 @@ class RcxDict {
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const kanjiInfoCode = this.kanjiInfoLabelList[i];
-        const kanjiInfoName = this.kanjiInfoLabelList[i + 1];
-        const kanjiInfo = entry.misc[kanjiInfoCode] || '-';
-        result.push(
-          kanjiInfoName.replace('&amp;', '&') + '\t' + kanjiInfo + '\n'
+        const kanjiInfoName = this.kanjiInfoLabelList[i + 1].replace(
+          '&amp;',
+          '&'
         );
+        const kanjiInfo = entry.misc[kanjiInfoCode] || '-';
+        result.push(kanjiInfoName + '\t' + kanjiInfo + '\n');
       }
     } else {
       if (max > entry.data.length) {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -987,8 +987,7 @@ class RcxDict {
           result.push(word);
         }
 
-        const t = definitions.replace(/\//g, '; ');
-        result.push('\t' + t + '\n');
+        result.push('\t' + definitions.replace(/\//g, '; ') + '\n');
       }
     }
     return result.join('');

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -944,24 +944,26 @@ class RcxDict {
       return '';
     }
 
-    const b = [];
+    const result = [];
 
     if (entry.kanji) {
-      b.push(entry.kanji + '\n');
-      b.push((entry.eigo.length ? entry.eigo : '-') + '\n');
+      result.push(entry.kanji + '\n');
+      result.push((entry.eigo.length ? entry.eigo : '-') + '\n');
 
-      b.push(entry.onkun.replace(/\.([^\u3001]+)/g, '\uFF08$1\uFF09') + '\n');
+      result.push(
+        entry.onkun.replace(/\.([^\u3001]+)/g, '\uFF08$1\uFF09') + '\n'
+      );
       if (entry.nanori.length) {
-        b.push('\u540D\u4E57\u308A\t' + entry.nanori + '\n');
+        result.push('\u540D\u4E57\u308A\t' + entry.nanori + '\n');
       }
       if (entry.bushumei.length) {
-        b.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
+        result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const e = this.kanjiInfoLabelList[i];
         const j = entry.misc[e];
-        b.push(
+        result.push(
           this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
             '\t' +
             (j || '-') +
@@ -981,16 +983,16 @@ class RcxDict {
         }
 
         if (e[2]) {
-          b.push(e[1] + '\t' + e[2]);
+          result.push(e[1] + '\t' + e[2]);
         } else {
-          b.push(e[1]);
+          result.push(e[1]);
         }
 
         const t = e[3].replace(/\//g, '; ');
-        b.push('\t' + t + '\n');
+        result.push('\t' + t + '\n');
       }
     }
-    return b.join('');
+    return result.join('');
   }
 }
 

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -940,7 +940,6 @@ class RcxDict {
   }
 
   makeText(entry: DictEntryData | null, max: number): string {
-    let e;
     let i;
     let j;
     let t;
@@ -964,7 +963,7 @@ class RcxDict {
       }
 
       for (i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
-        e = this.kanjiInfoLabelList[i];
+        const e = this.kanjiInfoLabelList[i];
         j = entry.misc[e];
         b.push(
           this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
@@ -978,7 +977,9 @@ class RcxDict {
         max = entry.data.length;
       }
       for (i = 0; i < max; ++i) {
-        e = entry.data[i].entry.match(/^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//);
+        const e = entry.data[i].entry.match(
+          /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//
+        );
         if (!e) {
           continue;
         }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -973,20 +973,20 @@ class RcxDict {
         max = entry.data.length;
       }
       for (let i = 0; i < max; ++i) {
-        const e = entry.data[i].entry.match(
+        const entryMatch = entry.data[i].entry.match(
           /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//
         );
-        if (!e) {
+        if (!entryMatch) {
           continue;
         }
 
-        if (e[2]) {
-          result.push(e[1] + '\t' + e[2]);
+        if (entryMatch[2]) {
+          result.push(entryMatch[1] + '\t' + entryMatch[2]);
         } else {
-          result.push(e[1]);
+          result.push(entryMatch[1]);
         }
 
-        const t = e[3].replace(/\//g, '; ');
+        const t = entryMatch[3].replace(/\//g, '; ');
         result.push('\t' + t + '\n');
       }
     }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -962,12 +962,10 @@ class RcxDict {
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const kanjiInfoCode = this.kanjiInfoLabelList[i];
+        const kanjiInfoName = this.kanjiInfoLabelList[i + 1];
         const kanjiInfo = entry.misc[kanjiInfoCode];
         result.push(
-          this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
-            '\t' +
-            (kanjiInfo || '-') +
-            '\n'
+          kanjiInfoName.replace('&amp;', '&') + '\t' + (kanjiInfo || '-') + '\n'
         );
       }
     } else {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -940,8 +940,6 @@ class RcxDict {
   }
 
   makeText(entry: DictEntryData | null, max: number): string {
-    let t;
-
     if (entry === null) {
       return '';
     }
@@ -988,7 +986,7 @@ class RcxDict {
           b.push(e[1]);
         }
 
-        t = e[3].replace(/\//g, '; ');
+        const t = e[3].replace(/\//g, '; ');
         b.push('\t' + t + '\n');
       }
     }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -962,11 +962,11 @@ class RcxDict {
 
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const kanjiInfoCode = this.kanjiInfoLabelList[i];
-        const j = entry.misc[kanjiInfoCode];
+        const kanjiInfo = entry.misc[kanjiInfoCode];
         result.push(
           this.kanjiInfoLabelList[i + 1].replace('&amp;', '&') +
             '\t' +
-            (j || '-') +
+            (kanjiInfo || '-') +
             '\n'
         );
       }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -963,9 +963,9 @@ class RcxDict {
       for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
         const kanjiInfoCode = this.kanjiInfoLabelList[i];
         const kanjiInfoName = this.kanjiInfoLabelList[i + 1];
-        const kanjiInfo = entry.misc[kanjiInfoCode];
+        const kanjiInfo = entry.misc[kanjiInfoCode] || '-';
         result.push(
-          kanjiInfoName.replace('&amp;', '&') + '\t' + (kanjiInfo || '-') + '\n'
+          kanjiInfoName.replace('&amp;', '&') + '\t' + kanjiInfo + '\n'
         );
       }
     } else {

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -86,6 +86,12 @@ describe('data.ts', function () {
   });
 
   describe('makeText', function () {
+    it('returns an empty string if null dict entry is passed in', function () {
+      const emptyString = rcxDict.makeText(null, /* max= */ 1);
+
+      expect(emptyString).to.equal('');
+    });
+
     describe('with a dict entry consisting of empty kanji but present data properties', function () {
       const nonKanjiDictEntry = {
         ...DEFAULT_DICT_ENTRY,
@@ -133,6 +139,48 @@ describe('data.ts', function () {
         expect(allDataEntriesAsText).to.equal(
           '<word-1>\t<pronunciation-1>\t<definition-1>; <definition-2>; <definition-3>\n<word-2>\t<definition-1>; <definition-2>\n'
         );
+      });
+
+      describe('when data entry is an invalid format', function () {
+        it('returns an empty string when all the data entries are an invalid format', function () {
+          const nonKanjiDictEntryWithInvalidEntry = {
+            ...DEFAULT_DICT_ENTRY,
+            data: [
+              { entry: '<invalid-format-entry>', reason: undefined },
+              { entry: '<invalid-format-entry-2>', reason: undefined },
+            ],
+          };
+
+          const emptyString = rcxDict.makeText(
+            nonKanjiDictEntryWithInvalidEntry,
+            /* max= */ 1
+          );
+
+          expect(emptyString).to.equal('');
+        });
+
+        it('returns a valid format data entry as text when there is an invalid format data entry and a valid format data entry', function () {
+          const nonKanjiDictEntryWithInvalidEntryAndValidEntry = {
+            ...DEFAULT_DICT_ENTRY,
+            data: [
+              { entry: '<invalid-format-entry>', reason: undefined },
+              {
+                entry:
+                  '<valid-word> [<valid-pronunciation>] /<valid-definition>/',
+                reason: undefined,
+              },
+            ],
+          };
+
+          const validEntryAsText = rcxDict.makeText(
+            nonKanjiDictEntryWithInvalidEntryAndValidEntry,
+            /* max= */ 2
+          );
+
+          expect(validEntryAsText).to.equal(
+            '<valid-word>\t<valid-pronunciation>\t<valid-definition>\n'
+          );
+        });
       });
     });
 


### PR DESCRIPTION
The goal of this pull request is to give variables in `makeText` more descriptive names so that the code is easier to understand. Some variables were also put into a more local scope so that they're easier to follow.

This pull request does not change the functionality of `makeText` - the copy-to-clipboard feature works exactly how it did before this pull request.

I tried to make this pull request have a small code diff so that it's easier to review. I plan on making more changes to `makeText` in subsequent pull requests which will make it even easier to understand.

Changes I plan on making in subsequent pull requests:
- Restructure the `kanjiInfoLabelList` array so that it's an array of objects - so its type might change to something like `{ kanjiInfoCode: string; kanjiInfoName: string }[]` so that it's easier to understand.
- Write a dict entry parsing function which is well-tested and unifies the parsing logic used in `makeText`, `makeHtml`, and the update-db.ts file.
- Change the `DictEntryData` type to represent the valid states of the application better - something like `type DictEntryData = KanjiDictEntry | WordDictEntry;`
