### PR TITLE
refactor(makeText): Make kanji info labels an array of objects

### DIFF
--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  kanjiInfoLabelList: string[] = [
+  private kanjiInfoLabelList: string[] = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private kanjiInfoLabelList = [
+  private KANJI_INFO_LABELS = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -947,7 +947,7 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
+      for (const { code, kanjiInfoLabel } of this.KANJI_INFO_LABELS) {
         const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private kanjiInfoLabelList: string[] = [
+  private kanjiInfoLabelList = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -613,33 +613,20 @@ class RcxDict {
         'K',  'Gakken Kanji Dictionary Index',
         'W',  'Korean Reading',
     */
-    'H',
-    'Halpern',
-    'L',
-    'Heisig 5th Edition',
-    'DN',
-    'Heisig 6th Edition',
-    'E',
-    'Henshall',
-    'DK',
-    'Kanji Learners Dictionary',
-    'DL',
-    'Kanji Learners Dictionary 2nd Edition',
-    'N',
-    'Nelson',
-    'V',
-    'New Nelson',
-    'Y',
-    'PinYin',
-    'P',
-    'Skip Pattern',
-    'IN',
-    'Tuttle Kanji &amp; Kana',
-    'I',
-    'Tuttle Kanji Dictionary',
-    'U',
-    'Unicode',
-  ];
+    { code: 'H', kanjiInfoLabel: 'Halpern' },
+    { code: 'L', kanjiInfoLabel: 'Heisig 5th Edition' },
+    { code: 'DN', kanjiInfoLabel: 'Heisig 6th Edition' },
+    { code: 'E', kanjiInfoLabel: 'Henshall' },
+    { code: 'DK', kanjiInfoLabel: 'Kanji Learners Dictionary' },
+    { code: 'DL', kanjiInfoLabel: 'Kanji Learners Dictionary 2nd Edition' },
+    { code: 'N', kanjiInfoLabel: 'Nelson' },
+    { code: 'V', kanjiInfoLabel: 'New Nelson' },
+    { code: 'Y', kanjiInfoLabel: 'PinYin' },
+    { code: 'P', kanjiInfoLabel: 'Skip Pattern' },
+    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji &amp; Kana' },
+    { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
+    { code: 'U', kanjiInfoLabel: 'Unicode' },
+  ] as const;
 
   // TODO: Entry should be extracted as separate type.
   makeHtml(entry: DictEntryData | null) {
@@ -960,13 +947,9 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
-        const kanjiInfoCode = this.kanjiInfoLabelList[i];
-        const kanjiInfoName = this.kanjiInfoLabelList[i + 1].replace(
-          '&amp;',
-          '&'
-        );
-        const kanjiInfo = entry.misc[kanjiInfoCode] || '-';
+      for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
+        const kanjiInfoName = kanjiInfoLabel.replace('&amp;', '&');
+        const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoName + '\t' + kanjiInfo + '\n');
       }
     } else {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -623,7 +623,7 @@ class RcxDict {
     { code: 'V', kanjiInfoLabel: 'New Nelson' },
     { code: 'Y', kanjiInfoLabel: 'PinYin' },
     { code: 'P', kanjiInfoLabel: 'Skip Pattern' },
-    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji &amp; Kana' },
+    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji & Kana' },
     { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
     { code: 'U', kanjiInfoLabel: 'Unicode' },
   ] as const;
@@ -948,9 +948,8 @@ class RcxDict {
       }
 
       for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
-        const kanjiInfoName = kanjiInfoLabel.replace('&amp;', '&');
         const kanjiInfo = entry.misc[code] || '-';
-        result.push(kanjiInfoName + '\t' + kanjiInfo + '\n');
+        result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }
     } else {
       if (max > entry.data.length) {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private KANJI_INFO_LABELS = [
+  private static KANJI_INFO_LABELS = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -947,7 +947,7 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (const { code, kanjiInfoLabel } of this.KANJI_INFO_LABELS) {
+      for (const { code, kanjiInfoLabel } of RcxDict.KANJI_INFO_LABELS) {
         const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,10 @@ class RcxDict {
     return entry;
   }
 
-  private static KANJI_INFO_LABELS = [
+  private static readonly KANJI_INFO_LABELS: {
+    code: string;
+    kanjiInfoLabel: string;
+  }[] = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -626,7 +629,7 @@ class RcxDict {
     { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji & Kana' },
     { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
     { code: 'U', kanjiInfoLabel: 'Unicode' },
-  ] as const;
+  ];
 
   // TODO: Entry should be extracted as separate type.
   makeHtml(entry: DictEntryData | null) {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -606,6 +606,7 @@ class RcxDict {
     kanjiInfoLabel: string;
   }[] = [
     /*
+      This is a small list of kanji info labels we currently don't include:
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
         'DO',  'P.G. O\'Neill Index',
@@ -615,6 +616,8 @@ class RcxDict {
         'MP',  'Morohashi Daikanwajiten Volume/Page',
         'K',  'Gakken Kanji Dictionary Index',
         'W',  'Korean Reading',
+      Here is a comprehensive up-to-date list of all the kanji info labels:
+        http://www.edrdg.org/wiki/index.php/KANJIDIC_Project
     */
     { code: 'H', kanjiInfoLabel: 'Halpern' },
     { code: 'L', kanjiInfoLabel: 'Heisig 5th Edition' },


### PR DESCRIPTION
The goal of this pull request is to simplify the `makeText` function by changing the kanji info labels type definition.

Changes:
- Change `kanjiInfoLabelList` type to `{ code: string; kanjiInfoLabel: string }[]`
- Use a for-of loop to iterate over `kanjiInfoLabelList`
- Replace `&amp;` with `&` so that code in `makeText` doesn't need to have code that does that
  - `kanjiInfoLabelList` was [only used in `makeText`](https://github.com/search?q=repo%3Amelink14%2Frikaikun%20kanjiInfoLabelList&type=code) so this change is safe to make
- Rename `kanjiInfoLabelList` to `KANJI_INFO_LABELS`
- Make `KANJI_INFO_LABELS` private and static and readonly

This pull request doesn't change the behavior of `makeText` or the copy-to-clipboard feature - it only refactors `makeText` to be more simple.