### PR TITLE
refactor(makeText): Use parseWordDictEntry in makeText

### DIFF
--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  kanjiInfoLabelList: string[] = [
+  private kanjiInfoLabelList: string[] = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -94,7 +94,7 @@ type WordDictEntry = {
   definitions: string[];
 };
 
-export const parseWordDictFields = (line: string): WordDictEntry | null => {
+export const parseWordDictEntry = (line: string): WordDictEntry | null => {
   const fields = line.match(WORD_DICT_ENTRY_REGEX);
   if (!fields) {
     return null;

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private kanjiInfoLabelList = [
+  private KANJI_INFO_LABELS = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -947,7 +947,7 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
+      for (const { code, kanjiInfoLabel } of this.KANJI_INFO_LABELS) {
         const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private kanjiInfoLabelList: string[] = [
+  private kanjiInfoLabelList = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -613,33 +613,20 @@ class RcxDict {
         'K',  'Gakken Kanji Dictionary Index',
         'W',  'Korean Reading',
     */
-    'H',
-    'Halpern',
-    'L',
-    'Heisig 5th Edition',
-    'DN',
-    'Heisig 6th Edition',
-    'E',
-    'Henshall',
-    'DK',
-    'Kanji Learners Dictionary',
-    'DL',
-    'Kanji Learners Dictionary 2nd Edition',
-    'N',
-    'Nelson',
-    'V',
-    'New Nelson',
-    'Y',
-    'PinYin',
-    'P',
-    'Skip Pattern',
-    'IN',
-    'Tuttle Kanji &amp; Kana',
-    'I',
-    'Tuttle Kanji Dictionary',
-    'U',
-    'Unicode',
-  ];
+    { code: 'H', kanjiInfoLabel: 'Halpern' },
+    { code: 'L', kanjiInfoLabel: 'Heisig 5th Edition' },
+    { code: 'DN', kanjiInfoLabel: 'Heisig 6th Edition' },
+    { code: 'E', kanjiInfoLabel: 'Henshall' },
+    { code: 'DK', kanjiInfoLabel: 'Kanji Learners Dictionary' },
+    { code: 'DL', kanjiInfoLabel: 'Kanji Learners Dictionary 2nd Edition' },
+    { code: 'N', kanjiInfoLabel: 'Nelson' },
+    { code: 'V', kanjiInfoLabel: 'New Nelson' },
+    { code: 'Y', kanjiInfoLabel: 'PinYin' },
+    { code: 'P', kanjiInfoLabel: 'Skip Pattern' },
+    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji &amp; Kana' },
+    { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
+    { code: 'U', kanjiInfoLabel: 'Unicode' },
+  ] as const;
 
   // TODO: Entry should be extracted as separate type.
   makeHtml(entry: DictEntryData | null) {
@@ -960,13 +947,9 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (let i = 0; i < this.kanjiInfoLabelList.length; i += 2) {
-        const kanjiInfoCode = this.kanjiInfoLabelList[i];
-        const kanjiInfoName = this.kanjiInfoLabelList[i + 1].replace(
-          '&amp;',
-          '&'
-        );
-        const kanjiInfo = entry.misc[kanjiInfoCode] || '-';
+      for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
+        const kanjiInfoName = kanjiInfoLabel.replace('&amp;', '&');
+        const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoName + '\t' + kanjiInfo + '\n');
       }
     } else {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -623,7 +623,7 @@ class RcxDict {
     { code: 'V', kanjiInfoLabel: 'New Nelson' },
     { code: 'Y', kanjiInfoLabel: 'PinYin' },
     { code: 'P', kanjiInfoLabel: 'Skip Pattern' },
-    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji &amp; Kana' },
+    { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji & Kana' },
     { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
     { code: 'U', kanjiInfoLabel: 'Unicode' },
   ] as const;
@@ -948,9 +948,8 @@ class RcxDict {
       }
 
       for (const { code, kanjiInfoLabel } of this.kanjiInfoLabelList) {
-        const kanjiInfoName = kanjiInfoLabel.replace('&amp;', '&');
         const kanjiInfo = entry.misc[code] || '-';
-        result.push(kanjiInfoName + '\t' + kanjiInfo + '\n');
+        result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }
     } else {
       if (max > entry.data.length) {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -86,6 +86,8 @@ interface DeinflectionRuleGroup {
   rules: DeinflectionRule[];
 }
 
+const WORD_DICT_ENTRY_REGEX = /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//;
+
 class RcxDict {
   private static instance: RcxDict;
 
@@ -786,14 +788,14 @@ class RcxDict {
         '<div class="w-title">Names Dictionary</div><table class="w-na-tb"><tr><td>'
       );
       for (i = 0; i < entry.data.length; ++i) {
-        e = entry.data[i].entry.match(/^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//);
+        e = entry.data[i].entry.match(WORD_DICT_ENTRY_REGEX);
         if (!e) {
           continue;
         }
 
         // the next two lines re-process the entries that contain separate
         // search key and spelling due to mixed hiragana/katakana spelling
-        const e3 = e[3].match(/^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//);
+        const e3 = e[3].match(WORD_DICT_ENTRY_REGEX);
         if (e3) {
           e = e3;
         }
@@ -871,7 +873,7 @@ class RcxDict {
         Math.min(this.config.maxDictEntries + entry.index, entry.data.length);
         ++i
       ) {
-        e = entry.data[i].entry.match(/^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//);
+        e = entry.data[i].entry.match(WORD_DICT_ENTRY_REGEX);
         if (!e) {
           continue;
         }
@@ -962,9 +964,7 @@ class RcxDict {
         max = entry.data.length;
       }
       for (let i = 0; i < max; ++i) {
-        const entryMatch = entry.data[i].entry.match(
-          /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//
-        );
+        const entryMatch = entry.data[i].entry.match(WORD_DICT_ENTRY_REGEX);
         if (!entryMatch) {
           continue;
         }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -986,11 +986,11 @@ class RcxDict {
         max = entry.data.length;
       }
       for (let i = 0; i < max; ++i) {
-        const entryMatch = entry.data[i].entry.match(WORD_DICT_ENTRY_REGEX);
-        if (!entryMatch) {
+        const wordDictEntry = parseWordDictEntry(entry.data[i].entry);
+        if (!wordDictEntry) {
           continue;
         }
-        const [_, word, pronunciation, definitions] = entryMatch;
+        const { word, pronunciation, definitions } = wordDictEntry;
 
         if (pronunciation) {
           result.push(word + '\t' + pronunciation);
@@ -998,7 +998,7 @@ class RcxDict {
           result.push(word);
         }
 
-        result.push('\t' + definitions.replace(/\//g, '; ') + '\n');
+        result.push('\t' + definitions.join('; ') + '\n');
       }
     }
     return result.join('');

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -88,6 +88,28 @@ interface DeinflectionRuleGroup {
 
 const WORD_DICT_ENTRY_REGEX = /^(.+?)\s+(?:\[(.*?)\])?\s*\/(.+)\//;
 
+type WordDictEntry = {
+  word: string;
+  pronunciation: string | null;
+  definitions: string[];
+};
+
+export const parseWordDictFields = (line: string): WordDictEntry | null => {
+  const fields = line.match(WORD_DICT_ENTRY_REGEX);
+  if (!fields) {
+    return null;
+  }
+  const [, word, pronunciation, definitions] = fields;
+  if (!word || !definitions) {
+    return null;
+  }
+  return {
+    word,
+    pronunciation: pronunciation || null,
+    definitions: definitions.split('/'),
+  };
+};
+
 class RcxDict {
   private static instance: RcxDict;
 

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,7 @@ class RcxDict {
     return entry;
   }
 
-  private KANJI_INFO_LABELS = [
+  private static KANJI_INFO_LABELS = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -947,7 +947,7 @@ class RcxDict {
         result.push('\u90E8\u9996\u540D\t' + entry.bushumei + '\n');
       }
 
-      for (const { code, kanjiInfoLabel } of this.KANJI_INFO_LABELS) {
+      for (const { code, kanjiInfoLabel } of RcxDict.KANJI_INFO_LABELS) {
         const kanjiInfo = entry.misc[code] || '-';
         result.push(kanjiInfoLabel + '\t' + kanjiInfo + '\n');
       }

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -601,7 +601,10 @@ class RcxDict {
     return entry;
   }
 
-  private static KANJI_INFO_LABELS = [
+  private static readonly KANJI_INFO_LABELS: {
+    code: string;
+    kanjiInfoLabel: string;
+  }[] = [
     /*
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
@@ -626,7 +629,7 @@ class RcxDict {
     { code: 'IN', kanjiInfoLabel: 'Tuttle Kanji & Kana' },
     { code: 'I', kanjiInfoLabel: 'Tuttle Kanji Dictionary' },
     { code: 'U', kanjiInfoLabel: 'Unicode' },
-  ] as const;
+  ];
 
   // TODO: Entry should be extracted as separate type.
   makeHtml(entry: DictEntryData | null) {

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -606,6 +606,7 @@ class RcxDict {
     kanjiInfoLabel: string;
   }[] = [
     /*
+      This is a small list of kanji info labels we currently don't include:
         'C',   'Classical Radical',
         'DR',  'Father Joseph De Roo Index',
         'DO',  'P.G. O\'Neill Index',
@@ -615,6 +616,8 @@ class RcxDict {
         'MP',  'Morohashi Daikanwajiten Volume/Page',
         'K',  'Gakken Kanji Dictionary Index',
         'W',  'Korean Reading',
+      Here is a comprehensive up-to-date list of all the kanji info labels:
+        http://www.edrdg.org/wiki/index.php/KANJIDIC_Project
     */
     { code: 'H', kanjiInfoLabel: 'Halpern' },
     { code: 'L', kanjiInfoLabel: 'Heisig 5th Edition' },

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -119,6 +119,17 @@ describe('data.ts', function () {
 
         expect(wordDictEntry).to.equal(null);
       });
+
+      it('returns null when you pass in a word dict line with badly formatted definitions', function () {
+        const badlyFormattedDefinitionsWordDictLine =
+          '<word> [<pronunciation>] /';
+
+        const wordDictEntry = parseWordDictEntry(
+          badlyFormattedDefinitionsWordDictLine
+        );
+
+        expect(wordDictEntry).to.equal(null);
+      });
     });
   });
 

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -1,5 +1,5 @@
 import { Config } from '../configuration';
-import { RcxDict } from '../data';
+import { RcxDict, parseWordDictEntry } from '../data';
 import { expect, use } from '@esm-bundle/chai';
 import chaiLike from 'chai-like';
 import chaiThings from 'chai-things';
@@ -82,6 +82,33 @@ describe('data.ts', function () {
       expect(
         rcxDict.wordSearch('ＤＶＤ-ＲＯＭ', /* doNames= */ false)?.data
       ).to.include.something.like({ entry: /^ＤＶＤ-ＲＯＭ .*/ });
+    });
+  });
+
+  describe('parseWordDictEntry', function () {
+    it('parses a word dict entry from a word dict line which has a word, pronunciation, and definitions', function () {
+      const wordDictLine =
+        '<word> [<pronunciation>] /<definition-1>/<definition-2>/<definition-3>/';
+
+      const wordDictEntry = parseWordDictEntry(wordDictLine);
+
+      expect(wordDictEntry).to.deep.equal({
+        word: '<word>',
+        pronunciation: '<pronunciation>',
+        definitions: ['<definition-1>', '<definition-2>', '<definition-3>'],
+      });
+    });
+
+    it('parses a word dict entry from a word dict line which has a word and definitions', function () {
+      const lineFromWordDictWithNoPronunciation =
+        '<word> /<definition-1>/<definition-2>/';
+      expect(
+        parseWordDictEntry(lineFromWordDictWithNoPronunciation)
+      ).to.deep.equal({
+        word: '<word>',
+        pronunciation: null,
+        definitions: ['<definition-1>', '<definition-2>'],
+      });
     });
   });
 

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -130,6 +130,14 @@ describe('data.ts', function () {
 
         expect(wordDictEntry).to.equal(null);
       });
+
+      it('returns null when you pass in a word dict line with no definitions', function () {
+        const wordDictLineWithNoDefinitions = '<word> [<pronunciation>] //';
+
+        const wordDictEntry = parseWordDictEntry(wordDictLineWithNoDefinitions);
+
+        expect(wordDictEntry).to.equal(null);
+      });
     });
   });
 

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -110,6 +110,16 @@ describe('data.ts', function () {
         definitions: ['<definition-1>', '<definition-2>'],
       });
     });
+
+    describe('with an invalid word dict line', function () {
+      it('returns null when you pass in an empty word dict line', function () {
+        const emptyWordDictLine = '';
+
+        const wordDictEntry = parseWordDictEntry(emptyWordDictLine);
+
+        expect(wordDictEntry).to.equal(null);
+      });
+    });
   });
 
   describe('makeText', function () {

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -99,7 +99,7 @@ describe('data.ts', function () {
       });
     });
 
-    it('parses a word dict entry from a word dict line which has a word and definitions', function () {
+    it('parses a word dict entry from a word dict line which has a word and definitions, but no pronunciation', function () {
       const lineFromWordDictWithNoPronunciation =
         '<word> /<definition-1>/<definition-2>/';
       expect(

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -102,9 +102,12 @@ describe('data.ts', function () {
     it('parses a word dict entry from a word dict line which has a word and definitions, but no pronunciation', function () {
       const lineFromWordDictWithNoPronunciation =
         '<word> /<definition-1>/<definition-2>/';
-      expect(
-        parseWordDictEntry(lineFromWordDictWithNoPronunciation)
-      ).to.deep.equal({
+
+      const wordDictEntry = parseWordDictEntry(
+        lineFromWordDictWithNoPronunciation
+      );
+
+      expect(wordDictEntry).to.deep.equal({
         word: '<word>',
         pronunciation: null,
         definitions: ['<definition-1>', '<definition-2>'],


### PR DESCRIPTION
The goal of this pull request is to replace inline word dict entry parsing with a call to parseWordDictEntry.

We can use parseWordDictEntry in other places in subsequent pull requests.

This pull request doesn't change any of the existing behavior - it only refactors the code.