### PR TITLE
build(deps): Downgrade Code Cov action to v3

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -74,7 +74,7 @@ jobs:
           add: . -- ':!screenshots'
           default_author: github_actions
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info


### PR DESCRIPTION
The v4 beta was not marked as such and thus dependabot upgraded it. Later v4 was removed causing the action to be not found.

See https://github.com/codecov/codecov-action/issues/1091