### PR TITLE
ci: Update node steps in all workflows to use an LTS node version

### DIFF
--- a/.github/workflows/lint-pr-title-body.yml
+++ b/.github/workflows/lint-pr-title-body.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.7
-      - name: Use Node.js 16
+      - name: Use LTS Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: '16'
+          node-version: lts/*
       - run: npm ci
         name: Install needed commitlint config
       - uses: melink14/action-lint-pull-request-title@master

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -27,12 +27,10 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Use Node.js 16
+      - name: Use LTS Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: '16'
-          # 8.6 has the lastest overrides support
-          check-latest: true
+          node-version: lts/*
       - name: Install Japanese Fonts
         run: |
           sudo apt-get update

--- a/.github/workflows/update-dicts.yml
+++ b/.github/workflows/update-dicts.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-node@v4.0.3
         with:
-          node-version: '16'
+          node-version: lts/*
       - name: Update dictionaries
         run: |
           npm ci --ignore-scripts


### PR DESCRIPTION
Also, removes the requirement to `check-latest` for presubmit since even old versions of npm support override now.