### PR TITLE
fix(manifest): Remove comment from manifest.json

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,7 @@
     "type": "module"
   },
   "action": {
-    // If only one icon available, setting default_icon to string is allowed.
+    "//": "If only one icon available, setting default_icon to string is allowed.",
     "default_icon": "images/ba.png"
   },
   "options_ui": {


### PR DESCRIPTION
Chrome supports json comments but semantic-release-chrome does not; preventing the release of chrome.

The comment is replaced with a "//" json key.