### PR TITLE
fix: Allow popup.css to be accessed from all URLs

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,7 +39,7 @@
   "web_accessible_resources": [
     {
       "resources": ["css/popup.css"],
-      "matches": ["*://*/*"]
+      "matches": ["<all_urls>"]
     }
   ]
 }


### PR DESCRIPTION
The * scheme only matches http and https so file URLs were being excluded.