### PR TITLE
fix(google-docs): Set docs_annotate_canvas property in a MV3 compliant manner

### DIFF
--- a/extension/docs-annotate-canvas.ts
+++ b/extension/docs-annotate-canvas.ts
@@ -1,10 +1,5 @@
-const injectedCode = `(function() {window['_docs_annotate_canvas_by_ext'] = '${chrome.runtime.id}';})();`;
+window['_docs_annotate_canvas_by_ext'] = 'jipdnfibhldikgcjhfnomkfpcebammhp';
 
-const script = document.createElement('script');
-script.textContent = injectedCode;
-(document.head || document.documentElement).appendChild(script);
-script.remove();
-
-// Empty export to satisfy `isolatedModules` compiler flag and allow including in tests.
+// Empty export to allow including in tests.
 // Removed in production builds.
 export {};

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,7 +33,8 @@
       "matches": ["https://docs.google.com/*"],
       "js": ["docs-annotate-canvas.js"],
       "run_at": "document_start",
-      "all_frames": true
+      "all_frames": true,
+      "world": "MAIN"
     }
   ],
   "web_accessible_resources": [

--- a/extension/test/docs-annotate-canvas_test.ts
+++ b/extension/test/docs-annotate-canvas_test.ts
@@ -1,6 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import chrome from 'sinon-chrome';
-import sinon from 'sinon';
 
 declare global {
   interface Window {
@@ -10,26 +8,14 @@ declare global {
 
 describe('docs-annotate-canvas.ts', function () {
   beforeEach(function () {
-    chrome.reset();
-    sinon.reset();
     delete window._docs_annotate_canvas_by_ext;
   });
 
-  it('should set special property to rikaikun extension ID when document.head exists', async function () {
-    chrome.runtime.id = 'test_special_id_head';
-
+  it('should set special property to rikaikun extension ID', async function () {
     await import('../docs-annotate-canvas.js');
 
-    expect(window._docs_annotate_canvas_by_ext).to.equal(chrome.runtime.id);
-  });
-
-  it('should set special property to rikaikun extension ID with no document.head', async function () {
-    sinon.stub(document, 'head').value(undefined);
-    chrome.runtime.id = 'test_special_id_no_head';
-
-    // Added query string to force reloading module, requires updating test-augments.d.ts.
-    await import('../docs-annotate-canvas.js?no-head');
-
-    expect(window._docs_annotate_canvas_by_ext).to.equal(chrome.runtime.id);
+    expect(window._docs_annotate_canvas_by_ext).to.equal(
+      'jipdnfibhldikgcjhfnomkfpcebammhp'
+    );
   });
 });

--- a/extension/test/test-augments.d.ts
+++ b/extension/test/test-augments.d.ts
@@ -1,2 +1,0 @@
-// Allows loading module again to test no head element.
-declare module '*?no-head' {}


### PR DESCRIPTION
New CSP changes means we can no longer inject a script into the MAIN world from the ISOLATED world.

Instead, we use the new `world` key to inject a simple script directly into the MAIN world.

One caveat of this is that we can no longer read the extension ID dynamically (as it's not available in MAIN world) so instead we hardcode it into the script as it extremely stable.

Fixes #2175