### PR TITLE
refactor: Remove unnecessary lint disable

### DIFF
--- a/extension/rikaicontent.ts
+++ b/extension/rikaicontent.ts
@@ -442,8 +442,6 @@ class RcxContent {
       case 66: {
         // b
         const rikaichan = (ev.currentTarget! as Window).rikaichan!;
-        // For some reason it claims it can be const even though it's decremented.
-        // eslint-disable-next-line prefer-const
         let ofs = rikaichan.uofs;
         for (i = 50; i > 0; --i) {
           rikaichan.uofs = --ofs!;


### PR DESCRIPTION
It seems some bug was fixed in the background, since if it was a dependency change it would have caused a failure then.