### PR TITLE
build(deps): Remove overrides now that they are no longer needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5776,6 +5776,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.0.tgz",
@@ -7960,6 +7973,19 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -23287,7 +23313,7 @@
         "@types/koa": "^2.11.6",
         "@types/ws": "^7.4.0",
         "@web/parse5-utils": "^2.1.0",
-        "chokidar": ">=3.6.0",
+        "chokidar": "^3.4.3",
         "clone": "^2.1.2",
         "es-module-lexer": "^1.0.0",
         "get-stream": "^6.0.0",
@@ -23463,7 +23489,7 @@
         "@types/istanbul-reports": "^3.0.0",
         "@web/browser-logs": "^0.4.0",
         "@web/dev-server-core": "^0.7.0",
-        "chokidar": ">=3.6.0",
+        "chokidar": "^3.4.3",
         "cli-cursor": "^3.1.0",
         "co-body": "^6.1.0",
         "convert-source-map": "^2.0.0",
@@ -24342,11 +24368,22 @@
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
         "fsevents": "~2.3.2",
-        "glob-parent": ">=5.1.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "chrome-launcher": {
@@ -25460,7 +25497,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
-        "glob-parent": ">=5.1.2",
+        "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -25899,9 +25936,20 @@
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": ">=5.1.2",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -121,10 +121,6 @@
     "vite-multiple-assets": "^2.2.4",
     "vite-plugin-filter-replace": "^0.1.13"
   },
-  "overrides": {
-    "chokidar": ">=3.6.0",
-    "glob-parent": ">=5.1.2"
-  },
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
lit-analyzer was updated sometime last year and chokidar I'm not sure but removing and running npm audit doesn't list any new vulnerabilites.

Fixes #1101