### PR TITLE
build(debugging): Don't limit resolution of source map locations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
       "sourceMaps": true,
       "trace": true,
       // Needed for vite based project.
-      "webRoot": "${workspaceFolder}/extension"
+      "webRoot": "${workspaceFolder}/extension",
+      // Without this source maps aren't found for vite.
+      // Might need optimization to avoid the wrong files being loaded sometimes.
+      "resolveSourceMapLocations": null
     }
   ]
 }


### PR DESCRIPTION
Without this, a cold start of vscode can't find sourcemaps for breakpoints.