### PR TITLE
refactor(formatting): Replace archived buggy import sorter with simple-import-sorter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,15 +1,15 @@
-import { configs as liteslint } from 'eslint-plugin-lit';
-import chaifriendlyeslint from 'eslint-plugin-chai-friendly';
 import eslint from '@eslint/js';
-import globals from 'globals';
+import prettiereslint from 'eslint-config-prettier';
+import chaifriendlyeslint from 'eslint-plugin-chai-friendly';
 import importeslint from 'eslint-plugin-import-x';
 import jsoneslint from 'eslint-plugin-json';
+import { configs as liteslint } from 'eslint-plugin-lit';
 import mochaeslint from 'eslint-plugin-mocha';
 import nodeeslint from 'eslint-plugin-n';
-import prettiereslint from 'eslint-config-prettier';
 import promiseeslint from 'eslint-plugin-promise';
-import sortImportsEs6Autofix from 'eslint-plugin-sort-imports-es6-autofix';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import tsdoc from 'eslint-plugin-tsdoc';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -29,7 +29,7 @@ export default tseslint.config(
   {
     plugins: {
       tsdoc,
-      'sort-imports-es6-autofix': sortImportsEs6Autofix,
+      'simple-import-sort': simpleImportSort,
       '@typescript-eslint': tseslint.plugin,
     },
 
@@ -78,7 +78,8 @@ export default tseslint.config(
 
       'linebreak-style': ['error', 'unix'],
       'no-tabs': 'error',
-      'sort-imports-es6-autofix/sort-imports-es6': 'error',
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
       'unicode-bom': 'error',
       'promise/prefer-await-to-then': 'error',
       curly: 'error',

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -1,7 +1,7 @@
-import { RcxDict } from './data';
-import { RcxMain } from './rikaichan';
 import { configPromise } from './configuration';
+import { RcxDict } from './data';
 import { setupOffscreenDocument } from './offscreen-setup';
+import { RcxMain } from './rikaichan';
 
 /**
  * Returns a promise for fully initialized RcxMain. Async due to config and

--- a/extension/options.ts
+++ b/extension/options.ts
@@ -1,7 +1,9 @@
 import 'lit-toast/lit-toast.js';
-import { Config, configPromise } from './configuration';
-import { LitElement, TemplateResult, css, html } from 'lit';
+
+import { css, html, LitElement, TemplateResult } from 'lit';
 import { until } from 'lit/directives/until.js';
+
+import { Config, configPromise } from './configuration';
 
 type OptionEvent = {
   target: HTMLInputElement;

--- a/extension/test/background_test.ts
+++ b/extension/test/background_test.ts
@@ -1,9 +1,10 @@
-import { Config } from '../configuration';
-import { RcxMain } from '../rikaichan';
 import { expect, use } from 'chai';
-import chrome from 'sinon-chrome';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import chrome from 'sinon-chrome';
+
+import { Config } from '../configuration';
+import { RcxMain } from '../rikaichan';
 
 use(sinonChai);
 

--- a/extension/test/chrome_stubs.ts
+++ b/extension/test/chrome_stubs.ts
@@ -3,8 +3,8 @@
  * APIs are available in SUT code.
  */
 
-import * as sinonChrome from 'sinon-chrome';
 import sinon from 'sinon';
+import * as sinonChrome from 'sinon-chrome';
 
 // Start by copying base sinon-chrome stubs into the window chrome
 // object

--- a/extension/test/data_test.ts
+++ b/extension/test/data_test.ts
@@ -1,9 +1,10 @@
-import { Config } from '../configuration';
-import { RcxDict } from '../data';
 import { expect, use } from 'chai';
 import chaiLike from 'chai-like';
 import chaiThings from 'chai-things';
 import sinonChrome from 'sinon-chrome';
+
+import { Config } from '../configuration';
+import { RcxDict } from '../data';
 
 // Extend chai-like to allow using regex for fuzzy string matching inside
 // objects.

--- a/extension/test/e2e_visual_test.ts
+++ b/extension/test/e2e_visual_test.ts
@@ -1,11 +1,12 @@
-import { Config } from '../configuration';
-import { TestOnlyRcxContent } from '../rikaicontent';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
-import { stubbedChrome as sinonChrome } from './chrome_stubs';
-import { use } from 'chai';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import { use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+
+import { Config } from '../configuration';
+import { TestOnlyRcxContent } from '../rikaicontent';
+import { stubbedChrome as sinonChrome } from './chrome_stubs';
 
 use(sinonChai);
 

--- a/extension/test/parse-word-dict-entry_test.ts
+++ b/extension/test/parse-word-dict-entry_test.ts
@@ -1,7 +1,8 @@
 import { expect, use } from 'chai';
-import { parseWordDictEntry } from '../parse-word-dict-entry';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+
+import { parseWordDictEntry } from '../parse-word-dict-entry';
 
 use(sinonChai);
 

--- a/extension/test/rikaicontent_test.ts
+++ b/extension/test/rikaicontent_test.ts
@@ -1,12 +1,13 @@
-import { Config } from '../configuration';
-import { DictEntryData } from '../data';
-import { TestOnlyRcxContent } from '../rikaicontent';
 import { expect, use } from 'chai';
 import { html, render } from 'lit-html';
-import chrome from 'sinon-chrome';
 import simulant from 'simulant';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import chrome from 'sinon-chrome';
+
+import { Config } from '../configuration';
+import { DictEntryData } from '../data';
+import { TestOnlyRcxContent } from '../rikaicontent';
 
 use(sinonChai);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "eslint-plugin-mocha": "^10.5.0",
         "eslint-plugin-n": "^17.15.0",
         "eslint-plugin-promise": "^7.2.1",
-        "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-tsdoc": "^0.4.0",
         "glob": "^11.0.0",
         "globals": "^15.13.0",
@@ -7498,13 +7498,14 @@
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
-    "node_modules/eslint-plugin-sort-imports-es6-autofix": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.6.0.tgz",
-      "integrity": "sha512-2NVaBGF9NN+727Fyq+jJYihdIeegjXeUUrZED9Q8FVB8MsV3YQEyXG96GVnXqWt0pmn7xfCZOZf3uKnIhBrfeQ==",
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=7.7.0"
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-tsdoc": {
@@ -25024,10 +25025,10 @@
         "@eslint-community/eslint-utils": "^4.4.0"
       }
     },
-    "eslint-plugin-sort-imports-es6-autofix": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.6.0.tgz",
-      "integrity": "sha512-2NVaBGF9NN+727Fyq+jJYihdIeegjXeUUrZED9Q8FVB8MsV3YQEyXG96GVnXqWt0pmn7xfCZOZf3uKnIhBrfeQ==",
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-n": "^17.15.0",
     "eslint-plugin-promise": "^7.2.1",
-    "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-tsdoc": "^0.4.0",
     "glob": "^11.0.0",
     "globals": "^15.13.0",

--- a/utils/update-db.ts
+++ b/utils/update-db.ts
@@ -5,6 +5,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 import { LineStream } from 'byline';
+import { parse } from 'csv-parse/sync';
+import fs, { promises as promiseFs, WriteStream } from 'fs';
+import http from 'http';
+import iconv from 'iconv-lite';
+import path from 'path';
 import {
   Transform,
   TransformCallback,
@@ -13,11 +18,6 @@ import {
   WritableOptions,
 } from 'stream';
 import { URL } from 'url';
-import { parse } from 'csv-parse/sync';
-import fs, { WriteStream, promises as promiseFs } from 'fs';
-import http from 'http';
-import iconv from 'iconv-lite';
-import path from 'path';
 import zlib from 'zlib';
 
 // prettier-ignore

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
-import { DynamicPublicDirectory } from 'vite-multiple-assets';
-import { defineConfig } from 'vite';
-import { fileURLToPath } from 'node:url';
-import { globSync } from 'glob';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { globSync } from 'glob';
+import { defineConfig } from 'vite';
+import { DynamicPublicDirectory } from 'vite-multiple-assets';
 import replace from 'vite-plugin-filter-replace';
 
 export default defineConfig({

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,8 +1,8 @@
-import { browserstackLauncher } from '@web/test-runner-browserstack';
+import { vitePlugin } from '@remcovaes/web-test-runner-vite-plugin';
 import { defaultReporter } from '@web/test-runner';
+import { browserstackLauncher } from '@web/test-runner-browserstack';
 import { puppeteerLauncher } from '@web/test-runner-puppeteer';
 import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugin';
-import { vitePlugin } from '@remcovaes/web-test-runner-vite-plugin';
 import isDocker from 'is-docker';
 
 // Set NODE_ENV to test for later use in vite.config.ts.


### PR DESCRIPTION
The old sorter was working fine but just recently it crashed during linting due to reliance once deprecated eslint methods.