### PR TITLE
build(lint): Disable comment capitalization in prettier

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,4 +5,5 @@ export default {
   trailingComma: 'es5',
   arrowParens: 'always',
   plugins: ['./node_modules/prettier-plugin-jsdoc/dist/index.js'],
+  jsdocCapitalizeDescription: false,
 };


### PR DESCRIPTION
This ends up causing parameter comments to be capitalized which we don't want.