### PR TITLE
Revert "build(lint): Disable comment capitalization in prettier"

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -5,5 +5,4 @@ export default {
   trailingComma: 'es5',
   arrowParens: 'always',
   plugins: ['./node_modules/prettier-plugin-jsdoc/dist/index.js'],
-  jsdocCapitalizeDescription: false,
 };


### PR DESCRIPTION
Reverts melink14/rikaikun#2340

It turns out it only triggers for jsdoc style `/**` comments and I had mistakenly used one for my inline comment which caused the problem. Reverting the change since my reason doesn't apply and it might be useful.