### PR TITLE
build(package): Upgrade node version to >=22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "rikaikun is a Chrome extension that helps you to read Japanese web pages by showing the reading and English definition of Japanese words when you hover over them.",
   "private": true,
   "engines": {
-    "node": ">=20.11.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This is the next LTS version that definitely supports import.meta.dirname. The previous attempt at this failed incorrectly pinned to the backport and thus didn't work.

Unblocks https://github.com/melink14/rikaikun/pull/2479