### PR TITLE
build(ci): Don't print an error when there are no failed screenshots during presubmit

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check for screenshot failures
         id: check-screenshots
         if: failure()
-        run: echo "screenshot_failure=$(ls -1 screenshots/Chromium/failed | wc -l)" >> $GITHUB_OUTPUT
+        run: echo "screenshot_failure=$(ls -1 screenshots/Chromium/failed 2>/dev/null | wc -l)" >> $GITHUB_OUTPUT
       - name: Upload failing screenshots and diffs
         uses: actions/upload-artifact@v4
         if: failure() && steps.check-screenshots.outputs.screenshot_failure > 0


### PR DESCRIPTION
Since the failed directory won't exist `ls` will always fail to list it's contents making it pure noise.