### PR TITLE
refactor: Remove loadNames and fileRead methods

### DIFF
--- a/extension/data.ts
+++ b/extension/data.ts
@@ -114,8 +114,8 @@ const defaultDictEntryData: DictEntryData = {
 class RcxDict {
   private static instance: RcxDict;
 
-  nameDict?: string;
-  nameIndex?: string;
+  nameDict: string;
+  nameIndex: string;
   wordDict = '';
   wordIndex = '';
   kanjiData = '';
@@ -171,22 +171,6 @@ class RcxDict {
     return file.split('\n').filter((line) => {
       return line && line.length > 0;
     });
-  }
-
-  private fileRead(url: string) {
-    const req = new XMLHttpRequest();
-    req.open('GET', url, false);
-    req.send(null);
-    return req.responseText;
-  }
-
-  private loadNames() {
-    if (this.nameDict && this.nameIndex) {
-      return;
-    }
-
-    this.nameDict = this.fileRead(chrome.runtime.getURL('data/names.dat'));
-    this.nameIndex = this.fileRead(chrome.runtime.getURL('data/names.idx'));
   }
 
   //  Note: These are mostly flat text files; loaded as one continuous string to
@@ -383,11 +367,8 @@ class RcxDict {
     if (doNames) {
       // check: split this
 
-      this.loadNames();
-      // After loadNames these are guaranteed to not be null so
-      // cast them as strings manually.
-      dict = this.nameDict as string;
-      index = this.nameIndex as string;
+      dict = this.nameDict;
+      index = this.nameIndex;
       maxTrim = 20; // this.config.namax;
       entry.hasNames = true;
       console.log('doNames');

--- a/extension/data.ts
+++ b/extension/data.ts
@@ -114,8 +114,8 @@ const defaultDictEntryData: DictEntryData = {
 class RcxDict {
   private static instance: RcxDict;
 
-  nameDict: string;
-  nameIndex: string;
+  nameDict = '';
+  nameIndex = '';
   wordDict = '';
   wordIndex = '';
   kanjiData = '';


### PR DESCRIPTION
The loadNames method and its underlying fileRead method (which used deprecated XMLHttpRequest) have been removed from the RcxDict class.

The name dictionary data (nameDict and nameIndex) is already initialized at startup using the fetch API within the init() method. The call to loadNames in wordSearch was therefore redundant as the data would always be present.

This change simplifies your codebase by removing unused methods and deprecated API usage, and makes nameDict and nameIndex non-nullable properties.

Fixes #2153