### PR TITLE
ci: Make presubmit environment conditional

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,7 +17,7 @@ jobs:
   presubmit:
     runs-on: ubuntu-22.04
     environment:
-      name: Presubmit Pre-Check
+      name: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && 'Presubmit Pre-Check' || '' }}
       deployment: false
     env:
       Editable: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Update the presubmit workflow so that the `Presubmit Pre-Check` environment is only applied on `pull_request_target` events when the actor is not dependabot.

---
*PR created automatically by Jules for task [5816934231557256071](https://jules.google.com/task/5816934231557256071) started by @melink14*